### PR TITLE
flexible-error-display: Added support for FlexibleMessageBox

### DIFF
--- a/FFXIV_TexTools2/App.xaml.cs
+++ b/FFXIV_TexTools2/App.xaml.cs
@@ -1,26 +1,34 @@
 ﻿using System;
 using System.Windows;
+using System.Windows.Forms;
+using FFXIV_TexTools2.Helpers;
+using Clipboard = System.Windows.Clipboard;
 
 namespace FFXIV_TexTools2
 {
+    /// <inheritdoc />
     /// <summary>
     /// Interaction logic for App.xaml
     /// </summary>
-    public partial class App : Application
+    public partial class App
     {
         protected override void OnStartup(StartupEventArgs e)
         {
             // hook on error before app really starts
-            AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(CurrentDomain_UnhandledException);
+            AppDomain.CurrentDomain.UnhandledException += CurrentDomain_UnhandledException;
             base.OnStartup(e);
         }
 
-        void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        private static void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
-            var line = "\n======================================================\n";
-            var message = "TexTools ran into an error. \n\nPlease submit a bug report with the following information.\n " + line +
-                e.ExceptionObject.ToString() + line + "\nCopy to clipboard?";
-            if (MessageBox.Show(message, "Crash Report", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
+            const string lineBreak = "\n======================================================\n";
+            var errorText = "TexTools ran into an error.\n\n" +
+                            "Please submit a bug report with the following information.\n " +
+                            lineBreak +
+                            e.ExceptionObject +
+                            lineBreak + "\n" +
+                            "Copy to clipboard?";
+            if (FlexibleMessageBox.Show(errorText, "Crash Report",MessageBoxButtons.YesNo,MessageBoxIcon.Error) ==DialogResult.Yes)
             {
                 Clipboard.SetText(e.ExceptionObject.ToString());
             }

--- a/FFXIV_TexTools2/FFXIV_TexTools2.csproj
+++ b/FFXIV_TexTools2/FFXIV_TexTools2.csproj
@@ -150,6 +150,7 @@
     <Compile Include="FileTypes\ModelContainers\ExtraIndexData.cs" />
     <Compile Include="FileTypes\ModelContainers\JsonSkeleton.cs" />
     <Compile Include="FileTypes\ModelContainers\Skeleton.cs" />
+    <Compile Include="Helpers\FlexibleMessageBox.cs" />
     <Compile Include="Helpers\JsonEntry.cs" />
     <Compile Include="Commands\RelayCommand.cs" />
     <Compile Include="Helpers\TexHelper.cs" />
@@ -381,9 +382,15 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="sharpdx_direct3d11_1_effects_arm.dll" />
-    <Content Include="sharpdx_direct3d11_1_effects_x64.dll" />
-    <Content Include="sharpdx_direct3d11_1_effects_x86.dll" />
+    <Content Include="sharpdx_direct3d11_1_effects_arm.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="sharpdx_direct3d11_1_effects_x64.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="sharpdx_direct3d11_1_effects_x86.dll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="x64\d3dcompiler_47.dll" />
     <Content Include="x86\d3dcompiler_47.dll" />
     <Resource Include="Resources\PaypalDonateButton.png" />

--- a/FFXIV_TexTools2/Helpers/FlexibleMessageBox.cs
+++ b/FFXIV_TexTools2/Helpers/FlexibleMessageBox.cs
@@ -1,0 +1,862 @@
+﻿using System;
+using System.Diagnostics;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace FFXIV_TexTools2.Helpers
+{
+    /*  FlexibleMessageBox – A flexible replacement for the .NETFlexibleMessageBox
+     * 
+     *  Author:         Jörg Reichert (public@jreichert.de)
+     *  Contributors:   Thanks to: David Hall, Roink
+     *  Version:        1.3
+     *  Published at:   http://www.codeproject.com/Articles/601900/FlexibleMessageBox
+     *  
+     ************************************************************************************************************
+     * Features:
+     *  - It can be simply used instead ofFlexibleMessageBox since all important static "Show"-Functions are supported
+     *  - It is small, only one source file, which could be added easily to each solution 
+     *  - It can be resized and the content is correctly word-wrapped
+     *  - It tries to auto-size the width to show the longest text row
+     *  - It never exceeds the current desktop working area
+     *  - It displays a vertical scrollbar when needed
+     *  - It does support hyperlinks in text
+     * 
+     *  Because the interface is identical toFlexibleMessageBox, you can add this single source file to your project 
+     *  and use the FlexibleMessageBox almost everywhere you use a standardFlexibleMessageBox. 
+     *  The goal was NOT to produce as many features as possible but to provide a simple replacement to fit my 
+     *  own needs. Feel free to add additional features on your own, but please left my credits in this class.
+     * 
+     ************************************************************************************************************
+     * Usage examples:
+     * 
+     *  FlexibleMessageBox.Show("Just a text");
+     * 
+     *  FlexibleMessageBox.Show("A text", 
+     *                          "A caption"); 
+     *  
+     *  FlexibleMessageBox.Show("Some text with a link: www.google.com", 
+     *                          "Some caption",
+     *                         MessageBoxButtons.AbortRetryIgnore, 
+     *                         MessageBoxIcon.Information,
+     *                         MessageBoxDefaultButton.Button2);
+     *  
+     *  var dialogResult = FlexibleMessageBox.Show("Do you know the answer to life the universe and everything?", 
+     *                                             "One short question",
+     *                                            MessageBoxButtons.YesNo);     
+     * 
+     ************************************************************************************************************
+     *  THE SOFTWARE IS PROVIDED BY THE AUTHOR "AS IS", WITHOUT WARRANTY
+     *  OF ANY KIND, EXPRESS OR IMPLIED. IN NO EVENT SHALL THE AUTHOR BE
+     *  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY ARISING FROM,
+     *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF THIS
+     *  SOFTWARE.
+     *  
+     ************************************************************************************************************
+     * History:
+     *  Version 1.3 - 19.Dezember 2014
+     *  - Added refactoring function GetButtonText()
+     *  - Used CurrentUICulture instead of InstalledUICulture
+     *  - Added more button localizations. Supported languages are now: ENGLISH, GERMAN, SPANISH, ITALIAN
+     *  - Added standardFlexibleMessageBox handling for "copy to clipboard" with <Ctrl> + <C> and <Ctrl> + <Insert>
+     *  - Tab handling is now corrected (only tabbing over the visible buttons)
+     *  - Added standardFlexibleMessageBox handling for ALT-Keyboard shortcuts
+     *  - SetDialogSizes: Refactored completely: Corrected sizing and added caption driven sizing
+     * 
+     *  Version 1.2 - 10.August 2013
+     *   - Do not ShowInTaskbar anymore (originalFlexibleMessageBox is also hidden in taskbar)
+     *   - Added handling for Escape-Button
+     *   - Adapted top right close button (red X) to behave likeFlexibleMessageBox (but hidden instead of deactivated)
+     * 
+     *  Version 1.1 - 14.June 2013
+     *   - Some Refactoring
+     *   - Added internal form class
+     *   - Added missing code comments, etc.
+     *  
+     *  Version 1.0 - 15.April 2013
+     *   - Initial Version
+    */
+    public class FlexibleMessageBox
+    {
+        #region Public statics
+
+        /// <summary>
+        /// Defines the maximum width for all FlexibleMessageBox instances in percent of the working area.
+        /// 
+        /// Allowed values are 0.2 - 1.0 where: 
+        /// 0.2 means:  The FlexibleMessageBox can be at most half as wide as the working area.
+        /// 1.0 means:  The FlexibleMessageBox can be as wide as the working area.
+        /// 
+        /// Default is: 70% of the working area width.
+        /// </summary>
+        public static double MAX_WIDTH_FACTOR = 0.7;
+
+        /// <summary>
+        /// Defines the maximum height for all FlexibleMessageBox instances in percent of the working area.
+        /// 
+        /// Allowed values are 0.2 - 1.0 where: 
+        /// 0.2 means:  The FlexibleMessageBox can be at most half as high as the working area.
+        /// 1.0 means:  The FlexibleMessageBox can be as high as the working area.
+        /// 
+        /// Default is: 90% of the working area height.
+        /// </summary>
+        public static double MAX_HEIGHT_FACTOR = 0.9;
+
+        /// <summary>
+        /// Defines the font for all FlexibleMessageBox instances.
+        /// 
+        /// Default is: SystemFonts.MessageBoxFont
+        /// </summary>
+        public static Font FONT = SystemFonts.MessageBoxFont;
+
+        #endregion
+
+        #region Public show functions
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(string text)
+        {
+            return FlexibleMessageBoxForm.Show(null, text, string.Empty,MessageBoxButtons.OK,MessageBoxIcon.None,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
+        /// <param name="text">The text.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(IWin32Window owner, string text)
+        {
+            return FlexibleMessageBoxForm.Show(owner, text, string.Empty,MessageBoxButtons.OK,MessageBoxIcon.None,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(string text, string caption)
+        {
+            return FlexibleMessageBoxForm.Show(null, text, caption, MessageBoxButtons.OK, MessageBoxIcon.None, MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(IWin32Window owner, string text, string caption)
+        {
+            return FlexibleMessageBoxForm.Show(owner, text, caption,MessageBoxButtons.OK,MessageBoxIcon.None,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <param name="buttons">The buttons.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(string text, string caption,MessageBoxButtons buttons)
+        {
+            return FlexibleMessageBoxForm.Show(null, text, caption, buttons,MessageBoxIcon.None,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <param name="buttons">The buttons.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(IWin32Window owner, string text, string caption,MessageBoxButtons buttons)
+        {
+            return FlexibleMessageBoxForm.Show(owner, text, caption, buttons,MessageBoxIcon.None,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <param name="buttons">The buttons.</param>
+        /// <param name="icon">The icon.</param>
+        /// <returns></returns>
+        public static DialogResult Show(string text, string caption,MessageBoxButtons buttons,MessageBoxIcon icon)
+        {
+            return FlexibleMessageBoxForm.Show(null, text, caption, buttons, icon,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <param name="buttons">The buttons.</param>
+        /// <param name="icon">The icon.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(IWin32Window owner, string text, string caption,MessageBoxButtons buttons,MessageBoxIcon icon)
+        {
+            return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, icon,MessageBoxDefaultButton.Button1);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <param name="buttons">The buttons.</param>
+        /// <param name="icon">The icon.</param>
+        /// <param name="defaultButton">The default button.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(string text, string caption,MessageBoxButtons buttons,MessageBoxIcon icon,MessageBoxDefaultButton defaultButton)
+        {
+            return FlexibleMessageBoxForm.Show(null, text, caption, buttons, icon, defaultButton);
+        }
+
+        /// <summary>
+        /// Shows the specified message box.
+        /// </summary>
+        /// <param name="owner">The owner.</param>
+        /// <param name="text">The text.</param>
+        /// <param name="caption">The caption.</param>
+        /// <param name="buttons">The buttons.</param>
+        /// <param name="icon">The icon.</param>
+        /// <param name="defaultButton">The default button.</param>
+        /// <returns>The dialog result.</returns>
+        public static DialogResult Show(IWin32Window owner, string text, string caption,MessageBoxButtons buttons,MessageBoxIcon icon,MessageBoxDefaultButton defaultButton)
+        {
+            return FlexibleMessageBoxForm.Show(owner, text, caption, buttons, icon, defaultButton);
+        }
+
+        #endregion
+
+        #region Internal form class
+
+        /// <summary>
+        /// The form to show the customized message box.
+        /// It is defined as an internal class to keep the public interface of the FlexibleMessageBox clean.
+        /// </summary>
+        class FlexibleMessageBoxForm : Form
+        {
+            #region Form-Designer generated code
+
+            /// <summary>
+            /// Erforderliche Designervariable.
+            /// </summary>
+            private System.ComponentModel.IContainer components = null;
+
+            /// <summary>
+            /// Verwendete Ressourcen bereinigen.
+            /// </summary>
+            /// <param name="disposing">True, wenn verwaltete Ressourcen gelöscht werden sollen; andernfalls False.</param>
+            protected override void Dispose(bool disposing)
+            {
+                if (disposing && (components != null))
+                {
+                    components.Dispose();
+                }
+                base.Dispose(disposing);
+            }
+
+            /// <summary>
+            /// Erforderliche Methode für die Designerunterstützung.
+            /// Der Inhalt der Methode darf nicht mit dem Code-Editor geändert werden.
+            /// </summary>
+            private void InitializeComponent()
+            {
+                this.components = new System.ComponentModel.Container();
+                this.button1 = new System.Windows.Forms.Button();
+                this.richTextBoxMessage = new System.Windows.Forms.RichTextBox();
+                this.FlexibleMessageBoxFormBindingSource = new System.Windows.Forms.BindingSource(this.components);
+                this.panel1 = new System.Windows.Forms.Panel();
+                this.pictureBoxForIcon = new System.Windows.Forms.PictureBox();
+                this.button2 = new System.Windows.Forms.Button();
+                this.button3 = new System.Windows.Forms.Button();
+                ((System.ComponentModel.ISupportInitialize)(this.FlexibleMessageBoxFormBindingSource)).BeginInit();
+                this.panel1.SuspendLayout();
+                ((System.ComponentModel.ISupportInitialize)(this.pictureBoxForIcon)).BeginInit();
+                this.SuspendLayout();
+                // 
+                // button1
+                // 
+                this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+                this.button1.AutoSize = true;
+                this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
+                this.button1.Location = new System.Drawing.Point(11, 67);
+                this.button1.MinimumSize = new System.Drawing.Size(0, 24);
+                this.button1.Name = "button1";
+                this.button1.Size = new System.Drawing.Size(75, 24);
+                this.button1.TabIndex = 2;
+                this.button1.Text = "OK";
+                this.button1.UseVisualStyleBackColor = true;
+                this.button1.Visible = false;
+                // 
+                // richTextBoxMessage
+                // 
+                this.richTextBoxMessage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                | System.Windows.Forms.AnchorStyles.Left)
+                | System.Windows.Forms.AnchorStyles.Right)));
+                this.richTextBoxMessage.BackColor = System.Drawing.Color.White;
+                this.richTextBoxMessage.BorderStyle = System.Windows.Forms.BorderStyle.None;
+                this.richTextBoxMessage.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.FlexibleMessageBoxFormBindingSource, "MessageText", true, System.Windows.Forms.DataSourceUpdateMode.OnPropertyChanged));
+                this.richTextBoxMessage.Font = new System.Drawing.Font("Microsoft Sans Serif", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+                this.richTextBoxMessage.Location = new System.Drawing.Point(50, 26);
+                this.richTextBoxMessage.Margin = new System.Windows.Forms.Padding(0);
+                this.richTextBoxMessage.Name = "richTextBoxMessage";
+                this.richTextBoxMessage.ReadOnly = true;
+                this.richTextBoxMessage.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+                this.richTextBoxMessage.Size = new System.Drawing.Size(200, 20);
+                this.richTextBoxMessage.TabIndex = 0;
+                this.richTextBoxMessage.TabStop = false;
+                this.richTextBoxMessage.Text = "<Message>";
+                this.richTextBoxMessage.LinkClicked += new System.Windows.Forms.LinkClickedEventHandler(this.richTextBoxMessage_LinkClicked);
+                // 
+                // panel1
+                // 
+                this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+                | System.Windows.Forms.AnchorStyles.Left)
+                | System.Windows.Forms.AnchorStyles.Right)));
+                this.panel1.BackColor = System.Drawing.Color.White;
+                this.panel1.Controls.Add(this.pictureBoxForIcon);
+                this.panel1.Controls.Add(this.richTextBoxMessage);
+                this.panel1.Location = new System.Drawing.Point(-3, -4);
+                this.panel1.Name = "panel1";
+                this.panel1.Size = new System.Drawing.Size(268, 59);
+                this.panel1.TabIndex = 1;
+                // 
+                // pictureBoxForIcon
+                // 
+                this.pictureBoxForIcon.BackColor = System.Drawing.Color.Transparent;
+                this.pictureBoxForIcon.Location = new System.Drawing.Point(15, 19);
+                this.pictureBoxForIcon.Name = "pictureBoxForIcon";
+                this.pictureBoxForIcon.Size = new System.Drawing.Size(32, 32);
+                this.pictureBoxForIcon.TabIndex = 8;
+                this.pictureBoxForIcon.TabStop = false;
+                // 
+                // button2
+                // 
+                this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+                this.button2.DialogResult = System.Windows.Forms.DialogResult.OK;
+                this.button2.Location = new System.Drawing.Point(92, 67);
+                this.button2.MinimumSize = new System.Drawing.Size(0, 24);
+                this.button2.Name = "button2";
+                this.button2.Size = new System.Drawing.Size(75, 24);
+                this.button2.TabIndex = 3;
+                this.button2.Text = "OK";
+                this.button2.UseVisualStyleBackColor = true;
+                this.button2.Visible = false;
+                // 
+                // button3
+                // 
+                this.button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+                this.button3.AutoSize = true;
+                this.button3.DialogResult = System.Windows.Forms.DialogResult.OK;
+                this.button3.Location = new System.Drawing.Point(173, 67);
+                this.button3.MinimumSize = new System.Drawing.Size(0, 24);
+                this.button3.Name = "button3";
+                this.button3.Size = new System.Drawing.Size(75, 24);
+                this.button3.TabIndex = 0;
+                this.button3.Text = "OK";
+                this.button3.UseVisualStyleBackColor = true;
+                this.button3.Visible = false;
+                // 
+                // FlexibleMessageBoxForm
+                // 
+                this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+                this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+                this.ClientSize = new System.Drawing.Size(260, 102);
+                this.Controls.Add(this.button3);
+                this.Controls.Add(this.button2);
+                this.Controls.Add(this.panel1);
+                this.Controls.Add(this.button1);
+                this.DataBindings.Add(new System.Windows.Forms.Binding("Text", this.FlexibleMessageBoxFormBindingSource, "CaptionText", true));
+                this.MaximizeBox = false;
+                this.MinimizeBox = false;
+                this.MinimumSize = new System.Drawing.Size(276, 140);
+                this.Name = "FlexibleMessageBoxForm";
+                this.ShowIcon = false;
+                this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Show;
+                this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+                this.Text = "<Caption>";
+                this.Shown += new System.EventHandler(this.FlexibleMessageBoxForm_Shown);
+                ((System.ComponentModel.ISupportInitialize)(this.FlexibleMessageBoxFormBindingSource)).EndInit();
+                this.panel1.ResumeLayout(false);
+                ((System.ComponentModel.ISupportInitialize)(this.pictureBoxForIcon)).EndInit();
+                this.ResumeLayout(false);
+                this.PerformLayout();
+            }
+
+            private System.Windows.Forms.Button button1;
+            private System.Windows.Forms.BindingSource FlexibleMessageBoxFormBindingSource;
+            private System.Windows.Forms.RichTextBox richTextBoxMessage;
+            private System.Windows.Forms.Panel panel1;
+            private System.Windows.Forms.PictureBox pictureBoxForIcon;
+            private System.Windows.Forms.Button button2;
+            private System.Windows.Forms.Button button3;
+
+            #endregion
+
+            #region Private constants
+
+            //These separators are used for the "copy to clipboard" standard operation, triggered by Ctrl + C (behavior and clipboard format is like in a standardFlexibleMessageBox)
+            private static readonly String STANDARD_MESSAGEBOX_SEPARATOR_LINES = "---------------------------\n";
+            private static readonly String STANDARD_MESSAGEBOX_SEPARATOR_SPACES = "   ";
+
+            //These are the possible buttons (in a standardFlexibleMessageBox)
+            private enum ButtonID { OK = 0, CANCEL, YES, NO, ABORT, RETRY, IGNORE };
+            
+            //These are the buttons texts for different languages. 
+            //If you want to add a new language, add it here and in the GetButtonText-Function
+            private enum TwoLetterISOLanguageID { en, de, es, it };
+            private static readonly String[] BUTTON_TEXTS_ENGLISH_EN = { "OK", "Cancel", "&Yes", "&No", "&Abort", "&Retry", "&Ignore" }; //Note: This is also the fallback language
+            private static readonly String[] BUTTON_TEXTS_GERMAN_DE = { "OK", "Abbrechen", "&Ja", "&Nein", "&Abbrechen", "&Wiederholen", "&Ignorieren" };
+            private static readonly String[] BUTTON_TEXTS_SPANISH_ES = { "Aceptar", "Cancelar", "&Sí", "&No", "&Abortar", "&Reintentar", "&Ignorar" };
+            private static readonly String[] BUTTON_TEXTS_ITALIAN_IT = { "OK", "Annulla", "&Sì", "&No", "&Interrompi", "&Riprova", "&Ignora" };
+
+            #endregion
+
+            #region Private members
+
+            private MessageBoxDefaultButton defaultButton;
+            private int visibleButtonsCount;
+            private TwoLetterISOLanguageID languageID = TwoLetterISOLanguageID.en;
+
+            #endregion
+
+            #region Private constructor
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="FlexibleMessageBoxForm"/> class.
+            /// </summary>
+            private FlexibleMessageBoxForm()
+            {
+                InitializeComponent();
+
+                //Try to evaluate the language. If this fails, the fallback language English will be used
+                Enum.TryParse<TwoLetterISOLanguageID>(CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, out this.languageID);
+
+                this.KeyPreview = true;
+                this.KeyUp += FlexibleMessageBoxForm_KeyUp;
+            }
+
+            #endregion
+
+            #region Private helper functions
+
+            /// <summary>
+            /// Gets the string rows.
+            /// </summary>
+            /// <param name="message">The message.</param>
+            /// <returns>The string rows as 1-dimensional array</returns>
+            private static string[] GetStringRows(string message)
+            {
+                if (string.IsNullOrEmpty(message)) return null;
+
+                var messageRows = message.Split(new char[] { '\n' }, StringSplitOptions.None);
+                return messageRows;
+            }
+
+            /// <summary>
+            /// Gets the button text for the CurrentUICulture language.
+            /// Note: The fallback language is English
+            /// </summary>
+            /// <param name="buttonID">The ID of the button.</param>
+            /// <returns>The button text</returns>
+            private string GetButtonText(ButtonID buttonID)
+            {
+                var buttonTextArrayIndex = Convert.ToInt32(buttonID);
+                
+                switch (this.languageID)
+                {
+                    case TwoLetterISOLanguageID.de: return BUTTON_TEXTS_GERMAN_DE[buttonTextArrayIndex];
+                    case TwoLetterISOLanguageID.es: return BUTTON_TEXTS_SPANISH_ES[buttonTextArrayIndex];
+                    case TwoLetterISOLanguageID.it: return BUTTON_TEXTS_ITALIAN_IT[buttonTextArrayIndex];
+
+                    default:                        return BUTTON_TEXTS_ENGLISH_EN[buttonTextArrayIndex];
+                }
+            }
+
+            /// <summary>
+            /// Ensure the given working area factor in the range of  0.2 - 1.0 where: 
+            /// 
+            /// 0.2 means:  20 percent of the working area height or width.
+            /// 1.0 means:  100 percent of the working area height or width.
+            /// </summary>
+            /// <param name="workingAreaFactor">The given working area factor.</param>
+            /// <returns>The corrected given working area factor.</returns>
+            private static double GetCorrectedWorkingAreaFactor(double workingAreaFactor)
+            {
+                const double MIN_FACTOR = 0.2;
+                const double MAX_FACTOR = 1.0;
+
+                if (workingAreaFactor < MIN_FACTOR) return MIN_FACTOR;
+                if (workingAreaFactor > MAX_FACTOR) return MAX_FACTOR;
+
+                return workingAreaFactor;
+            }
+
+            /// <summary>
+            /// Set the dialogs start position when given. 
+            /// Otherwise center the dialog on the current screen.
+            /// </summary>
+            /// <param name="flexibleMessageBoxForm">The FlexibleMessageBox dialog.</param>
+            /// <param name="owner">The owner.</param>
+            private static void SetDialogStartPosition(FlexibleMessageBoxForm flexibleMessageBoxForm, IWin32Window owner)
+            {
+                //If no owner given: Center on current screen
+                if (owner == null)
+                {
+                    var screen = Screen.FromPoint(Cursor.Position);
+                    flexibleMessageBoxForm.StartPosition = FormStartPosition.Manual;
+                    flexibleMessageBoxForm.Left = screen.Bounds.Left + screen.Bounds.Width / 2 - flexibleMessageBoxForm.Width / 2;
+                    flexibleMessageBoxForm.Top = screen.Bounds.Top + screen.Bounds.Height / 2 - flexibleMessageBoxForm.Height / 2;
+                }
+            }
+
+            /// <summary>
+            /// Calculate the dialogs start size (Try to auto-size width to show longest text row).
+            /// Also set the maximum dialog size. 
+            /// </summary>
+            /// <param name="flexibleMessageBoxForm">The FlexibleMessageBox dialog.</param>
+            /// <param name="text">The text (the longest text row is used to calculate the dialog width).</param>
+            /// <param name="text">The caption (this can also affect the dialog width).</param>
+            private static void SetDialogSizes(FlexibleMessageBoxForm flexibleMessageBoxForm, string text, string caption)
+            {
+                //First set the bounds for the maximum dialog size
+                flexibleMessageBoxForm.MaximumSize = new Size(Convert.ToInt32(SystemInformation.WorkingArea.Width * FlexibleMessageBoxForm.GetCorrectedWorkingAreaFactor(MAX_WIDTH_FACTOR)),
+                                                              Convert.ToInt32(SystemInformation.WorkingArea.Height * FlexibleMessageBoxForm.GetCorrectedWorkingAreaFactor(MAX_HEIGHT_FACTOR)));
+
+                //Get rows. Exit if there are no rows to render...
+                var stringRows = GetStringRows(text);
+                if (stringRows == null) return;
+
+                //Calculate whole text height
+                var textHeight = TextRenderer.MeasureText(text, FONT).Height;
+                    
+                //Calculate width for longest text line
+                const int SCROLLBAR_WIDTH_OFFSET = 15;
+                var longestTextRowWidth = stringRows.Max(textForRow => TextRenderer.MeasureText(textForRow, FONT).Width);
+                var captionWidth = TextRenderer.MeasureText(caption, SystemFonts.CaptionFont).Width;
+                var textWidth = Math.Max(longestTextRowWidth + SCROLLBAR_WIDTH_OFFSET, captionWidth);
+                
+                //Calculate margins
+                var marginWidth = flexibleMessageBoxForm.Width - flexibleMessageBoxForm.richTextBoxMessage.Width;
+                var marginHeight = flexibleMessageBoxForm.Height - flexibleMessageBoxForm.richTextBoxMessage.Height;
+
+                //Set calculated dialog size (if the calculated values exceed the maximums, they were cut by windows forms automatically)
+                flexibleMessageBoxForm.Size = new Size(textWidth + marginWidth,
+                                                       textHeight + marginHeight);
+            }
+
+            /// <summary>
+            /// Set the dialogs icon. 
+            /// When no icon is used: Correct placement and width of rich text box.
+            /// </summary>
+            /// <param name="flexibleMessageBoxForm">The FlexibleMessageBox dialog.</param>
+            /// <param name="icon">TheMessageBoxIcon.</param>
+            private static void SetDialogIcon(FlexibleMessageBoxForm flexibleMessageBoxForm,MessageBoxIcon icon)
+            {
+                switch (icon)
+                {
+                    case MessageBoxIcon.Information:
+                        flexibleMessageBoxForm.pictureBoxForIcon.Image = SystemIcons.Information.ToBitmap();
+                        break;
+                    case MessageBoxIcon.Warning:
+                        flexibleMessageBoxForm.pictureBoxForIcon.Image = SystemIcons.Warning.ToBitmap();
+                        break;
+                    case MessageBoxIcon.Error:
+                        flexibleMessageBoxForm.pictureBoxForIcon.Image = SystemIcons.Error.ToBitmap();
+                        break;
+                    case MessageBoxIcon.Question:
+                        flexibleMessageBoxForm.pictureBoxForIcon.Image = SystemIcons.Question.ToBitmap();
+                        break;
+                    default:
+                        //When no icon is used: Correct placement and width of rich text box.
+                        flexibleMessageBoxForm.pictureBoxForIcon.Visible = false;
+                        flexibleMessageBoxForm.richTextBoxMessage.Left -= flexibleMessageBoxForm.pictureBoxForIcon.Width;
+                        flexibleMessageBoxForm.richTextBoxMessage.Width += flexibleMessageBoxForm.pictureBoxForIcon.Width;
+                        break;
+                }
+            }
+
+            /// <summary>
+            /// Set dialog buttons visibilities and texts. 
+            /// Also set a default button.
+            /// </summary>
+            /// <param name="flexibleMessageBoxForm">The FlexibleMessageBox dialog.</param>
+            /// <param name="buttons">The buttons.</param>
+            /// <param name="defaultButton">The default button.</param>
+            private static void SetDialogButtons(FlexibleMessageBoxForm flexibleMessageBoxForm,MessageBoxButtons buttons,MessageBoxDefaultButton defaultButton)
+            {
+                //Set the buttons visibilities and texts
+                switch (buttons)
+                {
+                    case MessageBoxButtons.AbortRetryIgnore:
+                        flexibleMessageBoxForm.visibleButtonsCount = 3;
+
+                        flexibleMessageBoxForm.button1.Visible = true;
+                        flexibleMessageBoxForm.button1.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.ABORT);
+                        flexibleMessageBoxForm.button1.DialogResult = DialogResult.Abort;
+
+                        flexibleMessageBoxForm.button2.Visible = true;
+                        flexibleMessageBoxForm.button2.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.RETRY);
+                        flexibleMessageBoxForm.button2.DialogResult = DialogResult.Retry;
+
+                        flexibleMessageBoxForm.button3.Visible = true;
+                        flexibleMessageBoxForm.button3.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.IGNORE);
+                        flexibleMessageBoxForm.button3.DialogResult = DialogResult.Ignore;
+                        
+                        flexibleMessageBoxForm.ControlBox = false;
+                        break;
+
+                    case MessageBoxButtons.OKCancel:
+                        flexibleMessageBoxForm.visibleButtonsCount = 2;
+
+                        flexibleMessageBoxForm.button2.Visible = true;
+                        flexibleMessageBoxForm.button2.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.OK);
+                        flexibleMessageBoxForm.button2.DialogResult = DialogResult.OK;
+
+                        flexibleMessageBoxForm.button3.Visible = true;
+                        flexibleMessageBoxForm.button3.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.CANCEL);
+                        flexibleMessageBoxForm.button3.DialogResult = DialogResult.Cancel;
+
+                        flexibleMessageBoxForm.CancelButton = flexibleMessageBoxForm.button3;
+                        break;
+
+                    case MessageBoxButtons.RetryCancel:
+                        flexibleMessageBoxForm.visibleButtonsCount = 2;
+
+                        flexibleMessageBoxForm.button2.Visible = true;
+                        flexibleMessageBoxForm.button2.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.RETRY);
+                        flexibleMessageBoxForm.button2.DialogResult = DialogResult.Retry;
+
+                        flexibleMessageBoxForm.button3.Visible = true;
+                        flexibleMessageBoxForm.button3.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.CANCEL);
+                        flexibleMessageBoxForm.button3.DialogResult = DialogResult.Cancel;
+
+                        flexibleMessageBoxForm.CancelButton = flexibleMessageBoxForm.button3;
+                        break;
+
+                    case MessageBoxButtons.YesNo:
+                        flexibleMessageBoxForm.visibleButtonsCount = 2;
+
+                        flexibleMessageBoxForm.button2.Visible = true;
+                        flexibleMessageBoxForm.button2.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.YES);
+                        flexibleMessageBoxForm.button2.DialogResult = DialogResult.Yes;
+
+                        flexibleMessageBoxForm.button3.Visible = true;
+                        flexibleMessageBoxForm.button3.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.NO);
+                        flexibleMessageBoxForm.button3.DialogResult = DialogResult.No;
+
+                        flexibleMessageBoxForm.ControlBox = false;
+                        break;
+
+                    case MessageBoxButtons.YesNoCancel:
+                        flexibleMessageBoxForm.visibleButtonsCount = 3;
+
+                        flexibleMessageBoxForm.button1.Visible = true;
+                        flexibleMessageBoxForm.button1.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.YES);
+                        flexibleMessageBoxForm.button1.DialogResult = DialogResult.Yes;
+
+                        flexibleMessageBoxForm.button2.Visible = true;
+                        flexibleMessageBoxForm.button2.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.NO);
+                        flexibleMessageBoxForm.button2.DialogResult = DialogResult.No;
+
+                        flexibleMessageBoxForm.button3.Visible = true;
+                        flexibleMessageBoxForm.button3.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.CANCEL);
+                        flexibleMessageBoxForm.button3.DialogResult = DialogResult.Cancel;
+
+                        flexibleMessageBoxForm.CancelButton = flexibleMessageBoxForm.button3;
+                        break;
+
+                    case MessageBoxButtons.OK:
+                    default:
+                        flexibleMessageBoxForm.visibleButtonsCount = 1;
+                        flexibleMessageBoxForm.button3.Visible = true;
+                        flexibleMessageBoxForm.button3.Text = flexibleMessageBoxForm.GetButtonText(ButtonID.OK);
+                        flexibleMessageBoxForm.button3.DialogResult = DialogResult.OK;
+
+                        flexibleMessageBoxForm.CancelButton = flexibleMessageBoxForm.button3;
+                        break;
+                }
+
+                //Set default button (used in FlexibleMessageBoxForm_Shown)
+                flexibleMessageBoxForm.defaultButton = defaultButton;
+            }
+
+            #endregion
+
+            #region Private event handlers
+
+            /// <summary>
+            /// Handles the Shown event of the FlexibleMessageBoxForm control.
+            /// </summary>
+            /// <param name="sender">The source of the event.</param>
+            /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
+            private void FlexibleMessageBoxForm_Shown(object sender, EventArgs e)
+            {
+                int buttonIndexToFocus = 1;
+                Button buttonToFocus;
+
+                //Set the default button...
+                switch (this.defaultButton)
+                {
+                    case MessageBoxDefaultButton.Button1:
+                    default:
+                        buttonIndexToFocus = 1;
+                        break;
+                    case MessageBoxDefaultButton.Button2:
+                        buttonIndexToFocus = 2;
+                        break;
+                    case MessageBoxDefaultButton.Button3:
+                        buttonIndexToFocus = 3;
+                        break;
+                }
+
+                if (buttonIndexToFocus > this.visibleButtonsCount) buttonIndexToFocus = this.visibleButtonsCount;
+
+                if (buttonIndexToFocus == 3)
+                {
+                    buttonToFocus = this.button3;
+                }
+                else if (buttonIndexToFocus == 2)
+                {
+                    buttonToFocus = this.button2;
+                }
+                else
+                {
+                    buttonToFocus = this.button1;
+                }
+
+                buttonToFocus.Focus();
+            }
+
+            /// <summary>
+            /// Handles the LinkClicked event of the richTextBoxMessage control.
+            /// </summary>
+            /// <param name="sender">The source of the event.</param>
+            /// <param name="e">The <see cref="System.Windows.Forms.LinkClickedEventArgs"/> instance containing the event data.</param>
+            private void richTextBoxMessage_LinkClicked(object sender, LinkClickedEventArgs e)
+            {
+                try
+                {
+                    Cursor.Current = Cursors.WaitCursor;
+                    Process.Start(e.LinkText);
+                }
+                catch (Exception)
+                {
+                    //Let the caller of FlexibleMessageBoxForm decide what to do with this exception...
+                    throw;
+                }
+                finally
+                {
+                    Cursor.Current = Cursors.Default;
+                }
+
+            }
+
+            /// <summary>
+            /// Handles the KeyUp event of the richTextBoxMessage control.
+            /// </summary>
+            /// <param name="sender">The source of the event.</param>
+            /// <param name="e">The <see cref="System.Windows.Forms.KeyEventArgs"/> instance containing the event data.</param>
+            void FlexibleMessageBoxForm_KeyUp(object sender, KeyEventArgs e)
+            {
+                //Handle standard key strikes for clipboard copy: "Ctrl + C" and "Ctrl + Insert"
+                if (e.Control && (e.KeyCode == Keys.C || e.KeyCode == Keys.Insert))
+                {
+                    var buttonsTextLine = (this.button1.Visible ? this.button1.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty)
+                                        + (this.button2.Visible ? this.button2.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty)
+                                        + (this.button3.Visible ? this.button3.Text + STANDARD_MESSAGEBOX_SEPARATOR_SPACES : string.Empty);
+
+                    //Build same clipboard text like the standard .NetFlexibleMessageBox
+                    var textForClipboard = STANDARD_MESSAGEBOX_SEPARATOR_LINES
+                                         + this.Text + Environment.NewLine
+                                         + STANDARD_MESSAGEBOX_SEPARATOR_LINES
+                                         + this.richTextBoxMessage.Text + Environment.NewLine
+                                         + STANDARD_MESSAGEBOX_SEPARATOR_LINES
+                                         + buttonsTextLine.Replace("&", string.Empty) + Environment.NewLine
+                                         + STANDARD_MESSAGEBOX_SEPARATOR_LINES;
+
+                    //Set text in clipboard
+                    Clipboard.SetText(textForClipboard);
+                }
+            }
+
+            #endregion
+
+            #region Properties (only used for binding)
+
+            /// <summary>
+            /// The text that is been used for the heading.
+            /// </summary>
+            public string CaptionText { get; set; }
+
+            /// <summary>
+            /// The text that is been used in the FlexibleMessageBoxForm.
+            /// </summary>
+            public string MessageText { get; set; }
+
+            #endregion
+
+            #region Public show function
+
+            /// <summary>
+            /// Shows the specified message box.
+            /// </summary>
+            /// <param name="owner">The owner.</param>
+            /// <param name="text">The text.</param>
+            /// <param name="caption">The caption.</param>
+            /// <param name="buttons">The buttons.</param>
+            /// <param name="icon">The icon.</param>
+            /// <param name="defaultButton">The default button.</param>
+            /// <returns>The dialog result.</returns>
+            public static DialogResult Show(IWin32Window owner, string text, string caption,MessageBoxButtons buttons,MessageBoxIcon icon,MessageBoxDefaultButton defaultButton)
+            {
+                //Create a new instance of the FlexibleMessageBox form
+                var flexibleMessageBoxForm = new FlexibleMessageBoxForm();
+                flexibleMessageBoxForm.ShowInTaskbar = false;
+
+                //Bind the caption and the message text
+                flexibleMessageBoxForm.CaptionText = caption;
+                flexibleMessageBoxForm.MessageText = text;
+                flexibleMessageBoxForm.FlexibleMessageBoxFormBindingSource.DataSource = flexibleMessageBoxForm;
+
+                //Set the buttons visibilities and texts. Also set a default button.
+                SetDialogButtons(flexibleMessageBoxForm, buttons, defaultButton);
+
+                //Set the dialogs icon. When no icon is used: Correct placement and width of rich text box.
+                SetDialogIcon(flexibleMessageBoxForm, icon);
+
+                //Set the font for all controls
+                flexibleMessageBoxForm.Font = FONT;
+                flexibleMessageBoxForm.richTextBoxMessage.Font = FONT;
+
+                //Calculate the dialogs start size (Try to auto-size width to show longest text row). Also set the maximum dialog size. 
+                SetDialogSizes(flexibleMessageBoxForm, text, caption);
+
+                //Set the dialogs start position when given. Otherwise center the dialog on the current screen.
+                SetDialogStartPosition(flexibleMessageBoxForm, owner);
+
+                //Show the dialog
+                return flexibleMessageBoxForm.ShowDialog(owner);
+            }
+
+            #endregion
+        } //class FlexibleMessageBoxForm
+
+        #endregion
+    }
+}

--- a/FFXIV_TexTools2/Helpers/Helper.cs
+++ b/FFXIV_TexTools2/Helpers/Helper.cs
@@ -24,6 +24,8 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Windows;
+using System.Windows.Forms;
+
 
 namespace FFXIV_TexTools2.Helpers
 {
@@ -105,8 +107,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch(Exception e)
             {
-                MessageBox.Show("There was an issue reading EXD Data, submit a bug report with the following:\n\nError: " + e.Message + "\nFile: " + file +
-                    "\nPath: " + EXDDatPath + "\nOffset: " + offset, "[Helper] Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "EXD Data", true, EXDDatPath, offset);
             }
 
 
@@ -257,8 +258,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch(Exception e)
             {
-                MessageBox.Show("There was an issue reading Type 4 Data, submit a bug report with the following:\n\nError: " + e.Message +
-            "\nPath: " + datPath + "\nOffset: " + offset, "[Helper] Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "4 Data", true, datPath, offset);
             }
 
 
@@ -333,8 +333,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch(Exception e)
             {
-                MessageBox.Show("There was an issue reading Type 2 Data, submit a bug report with the following:\n\nError: " + e.Message +
-                            "\nPath: " + datPath + "\nOffset: " + offset, "[Helper] Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "2 Data", true, datPath, offset);
             }
 
             return type2Bytes.ToArray();
@@ -453,8 +452,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch(Exception e)
             {
-                MessageBox.Show("There was an issue reading Type 3 Data, submit a bug report with the following:\n\nError: " + e.Message +
-                    "\nPath: " + datPath + "\nOffset: " + offset, "[Helper] Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "3 Data", true, datPath, offset);
             }
 
 
@@ -525,7 +523,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch(Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
 
             return itemOffset;
@@ -579,7 +577,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index A File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index A File", false);
             }
 
             return exdOffset;
@@ -642,7 +640,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
 
             return oldOffset;
@@ -693,7 +691,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index 2 File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index 2 File", false);
             }
 
         }
@@ -736,7 +734,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
 
             return false;
@@ -787,7 +785,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
 
             return false;
@@ -827,7 +825,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
 
             return parts;
@@ -869,7 +867,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
 
             return raceList;
@@ -914,7 +912,7 @@ namespace FFXIV_TexTools2.Helpers
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                DisplayError(e, "Index File", false);
             }
             return fileOffsetDict;
         }
@@ -939,7 +937,7 @@ namespace FFXIV_TexTools2.Helpers
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    DisplayError(e, "Index File", false);
                 }
 
                 try
@@ -952,7 +950,7 @@ namespace FFXIV_TexTools2.Helpers
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("[Helper] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    DisplayError(e, "Index File", false);
                 }
             }
         }
@@ -1014,11 +1012,11 @@ namespace FFXIV_TexTools2.Helpers
                 {
                     if (showMessage)
                     {
-                        MessageBox.Show("Error Accessing Index File\n\n" +
+                       FlexibleMessageBox.Show("Error Accessing Index File\n\n" +
                         "Please exit the game before proceeding.\n" +
                         "-----------------------------------------------------\n\n" +
                         "Error Message:\n" +
-                        e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
 
                     return true;
@@ -1040,6 +1038,18 @@ namespace FFXIV_TexTools2.Helpers
         public static string ToTitleCase(string mString)
         {
             return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(mString.ToLower());
+        }
+
+        private static void DisplayError(Exception e, string dataType, bool shouldSubmit, string datPath = null, int? offset = null)
+        {
+                var errorText =
+                    "There was an issue reading " + dataType + ", "
+                    + (shouldSubmit ? "submit a bug report with the following:\n" : "") +
+                    "\nError: " + e.Message +
+                    (datPath != null ? "\nPath: " + datPath : "") + 
+                    (offset.HasValue ? "\nOffset: " + offset : "");
+
+                FlexibleMessageBox.Show(errorText, "[Helper] Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
         }
         #endregion Misc
     }

--- a/FFXIV_TexTools2/IO/CreateDat.cs
+++ b/FFXIV_TexTools2/IO/CreateDat.cs
@@ -19,6 +19,8 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Windows;
+using System.Windows.Forms;
+
 
 namespace FFXIV_TexTools2
 {
@@ -50,7 +52,7 @@ namespace FFXIV_TexTools2
             }
             catch (Exception e)
             {
-                MessageBox.Show("[Create] Error Creating .Dat4 File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Create] Error Creating .Dat4 File \n" + e.Message, "Error", MessageBoxButtons.OK,MessageBoxIcon.Error);
             }
         }
 
@@ -76,7 +78,7 @@ namespace FFXIV_TexTools2
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("[Create] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Create] Error Accessing Index File \n" + e.Message, "Error", MessageBoxButtons.OK,MessageBoxIcon.Error);
                 }
 
 
@@ -90,7 +92,7 @@ namespace FFXIV_TexTools2
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("[Create] Error Accessing Index 2 File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Create] Error Accessing Index 2 File \n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
@@ -172,7 +174,7 @@ namespace FFXIV_TexTools2
                 }
                 catch(Exception e)
                 {
-                    MessageBox.Show("[Create] Error Creating .modlist File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Create] Error Creating .modlist File \n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                 }
             }

--- a/FFXIV_TexTools2/IO/ExdReader.cs
+++ b/FFXIV_TexTools2/IO/ExdReader.cs
@@ -24,6 +24,9 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows;
+using System.Windows.Forms;
+
+using TreeNode = FFXIV_TexTools2.Model.TreeNode;
 
 namespace FFXIV_TexTools2.IO
 {
@@ -1419,7 +1422,7 @@ namespace FFXIV_TexTools2.IO
             }
             catch(Exception e)
             {
-                MessageBox.Show("Error at .\nItem: " + item.ItemName + "\nCategory: " + item.ItemCategory  + "\n\n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("Error at .\nItem: " + item.ItemName + "\nCategory: " + item.ItemCategory  + "\n\n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
             var scNode = new TreeNode() { Name = item.ItemName, ItemData = item };
             itemDict.Add(catName, new TreeNode() { Name = catName, _subNode = new List<TreeNode>() { scNode } });
@@ -1681,7 +1684,7 @@ namespace FFXIV_TexTools2.IO
 
             if(errorCount > 0)
             {
-                MessageBox.Show("TexTools ran into errors reading the items list.\n\nError Count: " + errorCount, "EXD Read Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("TexTools ran into errors reading the items list.\n\nError Count: " + errorCount, "EXD Read Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             foreach (var i in itemDict.Values)

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Forms;
 using System.Xml;
 
 namespace FFXIV_TexTools2.IO
@@ -161,7 +162,7 @@ namespace FFXIV_TexTools2.IO
 
 				if(boneJointDict.Count < 1)
 				{
-					MessageBox.Show("[Import] No bones were found in the .dae file.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+					FlexibleMessageBox.Show("[Import] No bones were found in the .dae file.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 					return;
 				}
 
@@ -213,12 +214,12 @@ namespace FFXIV_TexTools2.IO
                                     }
                                     else if (!tool.Contains("TexTools"))
                                     {
-                                        MessageBox.Show("Unsupported Authoring Tool\n\n" +
+                                        FlexibleMessageBox.Show("Unsupported Authoring Tool\n\n" +
                                             tool +
                                             "\n\nCurrently supported tools are:\n" +
                                             "* 3DS Max with default(FBX) or OpenCOLLADA plugin\n" +
                                             "* Blender with \"Better\" Collada exporter plugin\n\n" +
-                                            "If you'd like to get another tool supported, submit a request.", "Unsupported File", MessageBoxButton.OK, MessageBoxImage.Error);
+                                            "If you'd like to get another tool supported, submit a request.", "Unsupported File", MessageBoxButtons.OK, MessageBoxIcon.Error);
                                         return;
                                     }
                                 }
@@ -436,13 +437,13 @@ namespace FFXIV_TexTools2.IO
                             bones += "* " + b + "\n";
                         }
 
-                        MessageBox.Show("TexTools detected bones that are not part of the original model.\n" +
-                            "Importing extra bones is not supported, delete the extra bones and try importing again.\n\nExtra Bone(s):\n" + bones, "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                       FlexibleMessageBox.Show("TexTools detected bones that are not part of the original model.\n" +
+                            "Importing extra bones is not supported, delete the extra bones and try importing again.\n\nExtra Bone(s):\n" + bones, "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                     }
                     else
                     {
-                        MessageBox.Show("Error reading .dae file.\n" + e.Message, "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        FlexibleMessageBox.Show("Error reading .dae file.\n" + e.Message, "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
 					return;
 				}
@@ -462,15 +463,15 @@ namespace FFXIV_TexTools2.IO
                         {
                             if(mDict[j].texCoord.Count < 1)
                             {
-                                MessageBox.Show("TexTools detected missing Texture Coordinates for:\nMesh: " + i + " Part: " + j 
-                                    + "\n\nPlease check your model before importing again.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                                FlexibleMessageBox.Show("TexTools detected missing Texture Coordinates for:\nMesh: " + i + " Part: " + j 
+                                    + "\n\nPlease check your model before importing again.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                                 return;
                             }
 
                             if (mDict[j].weights.Count < 1)
                             {
-                                MessageBox.Show("TexTools detected missing Bone Data for:\nMesh: " + i + " Part: " + j
-                                    + "\n\nPlease check your model before importing again.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                                FlexibleMessageBox.Show("TexTools detected missing Bone Data for:\nMesh: " + i + " Part: " + j
+                                    + "\n\nPlease check your model before importing again.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                                 return;
                             }
                         }
@@ -711,9 +712,9 @@ namespace FFXIV_TexTools2.IO
                     }
                     catch
                     {
-                        MessageBox.Show("TexTools detected that mesh " + m + " refrences bones that were not originally part of that mesh.\n\n" +
+                       FlexibleMessageBox.Show("TexTools detected that mesh " + m + " refrences bones that were not originally part of that mesh.\n\n" +
                             "This may cause things to not look correct in-game, but will most likely be fine.\n\n" +
-                            "TexTools will now continue importing.", "Mesh Import Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                            "TexTools will now continue importing.", "Mesh Import Warning",MessageBoxButtons.OK,MessageBoxIcon.Warning);
 
                         vTrack = 0;
                         blDict.Clear();
@@ -788,8 +789,8 @@ namespace FFXIV_TexTools2.IO
 					}
 					catch(Exception e)
 					{
-						MessageBox.Show("[Import] Error reading skinning data.\nPlease make sure the skinning data was saved to the .dae file.\n\n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
-						Debug.WriteLine(e.StackTrace);
+						FlexibleMessageBox.Show("[Import] Error reading skinning data.\nPlease make sure the skinning data was saved to the .dae file.\n\n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        Debug.WriteLine(e.StackTrace);
 						return;
 					}
 
@@ -803,8 +804,8 @@ namespace FFXIV_TexTools2.IO
 						}
 
 
-						MessageBox.Show("TexTools detected an affected bone count greater than 4.\n\n" +
-							"TexTools removed the smallest weight counts from the following: \n\n" + errorString, "Over Weight Count", MessageBoxButton.OK, MessageBoxImage.Information);
+						FlexibleMessageBox.Show("TexTools detected an affected bone count greater than 4.\n\n" +
+							"TexTools removed the smallest weight counts from the following: \n\n" + errorString, "Over Weight Count",MessageBoxButtons.OK,MessageBoxIcon.Information);
 					}
 
 					Dictionary<int, int> indexDict = new Dictionary<int, int>();
@@ -899,7 +900,7 @@ namespace FFXIV_TexTools2.IO
 					}
 					catch (Exception e)
 					{
-						MessageBox.Show("[Import] Error computing tangents.\n\n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+						FlexibleMessageBox.Show("[Import] Error computing tangents.\n\n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 						return;
 					}
 
@@ -1003,7 +1004,7 @@ namespace FFXIV_TexTools2.IO
 			}
 			catch (Exception ex)
 			{
-				MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+				FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 			/*
 			* Imported Vertex Data Start
@@ -2650,14 +2651,14 @@ namespace FFXIV_TexTools2.IO
             {
                 if (modEntry.modOffset == 0)
                 {
-                    MessageBox.Show("TexTools detected a Mod List entry with a Mod Offset of 0.\n\n" +
-                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("TexTools detected a Mod List entry with a Mod Offset of 0.\n\n" +
+                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return 0;
                 }
                 else if (modEntry.originalOffset == 0)
                 {
-                    MessageBox.Show("TexTools detected a Mod List entry with an Original Offset of 0.\n\n" +
-                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                   FlexibleMessageBox.Show("TexTools detected a Mod List entry with an Original Offset of 0.\n\n" +
+                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return 0;
                 }
             }
@@ -2774,7 +2775,7 @@ namespace FFXIV_TexTools2.IO
 						}
 						catch (Exception ex)
 						{
-							MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+							FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 						}
 
 
@@ -2803,8 +2804,8 @@ namespace FFXIV_TexTools2.IO
 							}
 							else
 							{
-								MessageBox.Show("[Import] There was an issue obtaining the .dat4 offset to write data to, try importing again. " +
-												"\n\n If the problem persists, please submit a bug report.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+								FlexibleMessageBox.Show("[Import] There was an issue obtaining the .dat4 offset to write data to, try importing again. " +
+												"\n\n If the problem persists, please submit a bug report.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 								return 0;
 							}
 						}
@@ -2813,7 +2814,7 @@ namespace FFXIV_TexTools2.IO
 			}
 			catch (Exception ex)
 			{
-				MessageBox.Show("[Import] Error Accessing .dat4 File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+				FlexibleMessageBox.Show("[Import] Error Accessing .dat4 File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 				return 0;
 			}
 
@@ -2870,7 +2871,7 @@ namespace FFXIV_TexTools2.IO
 					}
 					catch (Exception ex)
 					{
-						MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+						FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 					}
 				}
 			}

--- a/FFXIV_TexTools2/IO/ImportTex.cs
+++ b/FFXIV_TexTools2/IO/ImportTex.cs
@@ -24,6 +24,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Text;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace FFXIV_TexTools2.IO
 {
@@ -77,7 +78,7 @@ namespace FFXIV_TexTools2.IO
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 using (BinaryReader br = new BinaryReader(File.OpenRead(savePath)))
@@ -137,13 +138,13 @@ namespace FFXIV_TexTools2.IO
                     }
                     else
                     {
-                        MessageBox.Show("Incorrect file type \nExpected: " + Info.TextureTypes[texData.Type] + " Given: " + Info.TextureTypes[textureType], "Texture format error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        FlexibleMessageBox.Show("Incorrect file type \nExpected: " + Info.TextureTypes[texData.Type] + " Given: " + Info.TextureTypes[textureType], "Texture format error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
             }
             else
             {
-                MessageBox.Show("Could not find file \n" + savePath, "File read Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("Could not find file \n" + savePath, "File read Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             return offset;
@@ -194,7 +195,7 @@ namespace FFXIV_TexTools2.IO
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
 
@@ -296,7 +297,7 @@ namespace FFXIV_TexTools2.IO
             }
             else
             {
-                MessageBox.Show("Could not find file \n" + savePath, "File read Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("Could not find file \n" + savePath, "File read Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return new Tuple<int, byte[]>(0, null);
             }
 
@@ -346,7 +347,7 @@ namespace FFXIV_TexTools2.IO
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
 
@@ -382,7 +383,7 @@ namespace FFXIV_TexTools2.IO
                     }
                     else
                     {
-                        MessageBox.Show("Incorrect file type \nExpected: " + Info.TextureTypes[texData.Type] + " Given: " + Info.TextureTypes[textureType], "Texture format error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        FlexibleMessageBox.Show("Incorrect file type \nExpected: " + Info.TextureTypes[texData.Type] + " Given: " + Info.TextureTypes[textureType], "Texture format error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         return 0;
                     }
                 }
@@ -639,14 +640,14 @@ namespace FFXIV_TexTools2.IO
             {
                 if(modEntry.modOffset == 0)
                 {
-                    MessageBox.Show("TexTools detected a Mod List entry with a Mod Offset of 0.\n\n" +
-                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                   FlexibleMessageBox.Show("TexTools detected a Mod List entry with a Mod Offset of 0.\n\n" +
+                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return 0;
                 }
                 else if (modEntry.originalOffset == 0)
                 {
-                    MessageBox.Show("TexTools detected a Mod List entry with an Original Offset of 0.\n\n" +
-                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                   FlexibleMessageBox.Show("TexTools detected a Mod List entry with an Original Offset of 0.\n\n" +
+                        "Please submit a bug report along with your modlist file.", "Import Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return 0;
                 }
             }
@@ -761,7 +762,7 @@ namespace FFXIV_TexTools2.IO
                         }
                         catch (Exception ex)
                         {
-                            MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                            FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                         }
 
                         if (!dataOverwritten)
@@ -789,8 +790,8 @@ namespace FFXIV_TexTools2.IO
                             }
                             else
                             {
-                                MessageBox.Show("[Import] There was an issue obtaining the .dat4 offset to write data to, try importing again. " +
-                                    "\n\n If the problem persists, please submit a bug report.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                               FlexibleMessageBox.Show("[Import] There was an issue obtaining the .dat4 offset to write data to, try importing again. " +
+                                    "\n\n If the problem persists, please submit a bug report.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             }
 
                         }
@@ -799,7 +800,7 @@ namespace FFXIV_TexTools2.IO
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Import] Error Accessing .dat4 File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Import] Error Accessing .dat4 File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return 0;
             }
 
@@ -856,7 +857,7 @@ namespace FFXIV_TexTools2.IO
                     }
                     catch (Exception ex)
                     {
-                        MessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        FlexibleMessageBox.Show("[Import] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
             }

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -28,6 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Media.Imaging;
 using System.Xml;
 
@@ -281,13 +282,13 @@ namespace FFXIV_TexTools2.IO
                 }
                 catch
                 {
-                    MessageBox.Show("There was an issue reading the skeleton file.\n\nYour AssetCc2.exe may be outdated, version 2012+ is required.", "Save Model Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("There was an issue reading the skeleton file.\n\nYour AssetCc2.exe may be outdated, version 2012+ is required.", "Save Model Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     return false;
                 }
             }
             else if(runAsset && !hasAssetcc)
             {
-                MessageBox.Show("No skeleton found for item. No .dae file will be saved. \n\nPlace AssetCc2(Not provided) in root folder to create skeleton.", "Save Model Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("No skeleton found for item. No .dae file will be saved. \n\nPlace AssetCc2(Not provided) in root folder to create skeleton.", "Save Model Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return false;
             }
 
@@ -410,7 +411,7 @@ namespace FFXIV_TexTools2.IO
                     }
                     else
                     {
-                        MessageBox.Show("[SaveModel] Unknown Data format (" + format + ") please submit a bug report.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        FlexibleMessageBox.Show("[SaveModel] Unknown Data format (" + format + ") please submit a bug report.", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                         throw new FormatException();
                     }

--- a/FFXIV_TexTools2/MainWindow.xaml.cs
+++ b/FFXIV_TexTools2/MainWindow.xaml.cs
@@ -23,8 +23,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Application = System.Windows.Application;
 
 namespace FFXIV_TexTools2
 {
@@ -76,7 +78,7 @@ namespace FFXIV_TexTools2
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Main] DX Switch Error \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Main] DX Switch Error \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -102,7 +104,7 @@ namespace FFXIV_TexTools2
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Main] DX Switch Error \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Main] DX Switch Error \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
         }
@@ -127,7 +129,7 @@ namespace FFXIV_TexTools2
 
         private void Menu_English_Click(object sender, RoutedEventArgs e)
         {
-            if (MessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change", MessageBoxButton.OKCancel, MessageBoxImage.Information) == MessageBoxResult.OK)
+            if (FlexibleMessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change",MessageBoxButtons.OKCancel,MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.OK)
             {
                 Properties.Settings.Default.Language = "en";
                 Properties.Settings.Default.Save();
@@ -145,7 +147,7 @@ namespace FFXIV_TexTools2
         {
 
 
-            if (MessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change", MessageBoxButton.OKCancel, MessageBoxImage.Information) == MessageBoxResult.OK)
+            if (FlexibleMessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change",MessageBoxButtons.OKCancel,MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.OK)
             {
                 Properties.Settings.Default.Language = "ja";
                 Properties.Settings.Default.Save();
@@ -161,7 +163,7 @@ namespace FFXIV_TexTools2
 
         private void Menu_French_Click(object sender, RoutedEventArgs e)
         {
-            if (MessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change", MessageBoxButton.OKCancel, MessageBoxImage.Information) == MessageBoxResult.OK)
+            if (FlexibleMessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change",MessageBoxButtons.OKCancel,MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.OK)
             {
                 Properties.Settings.Default.Language = "fr";
                 Properties.Settings.Default.Save();
@@ -177,7 +179,7 @@ namespace FFXIV_TexTools2
 
         private void Menu_German_Click(object sender, RoutedEventArgs e)
         {
-            if (MessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change", MessageBoxButton.OKCancel, MessageBoxImage.Information) == MessageBoxResult.OK)
+            if (FlexibleMessageBox.Show("Changing language requires the application to restart. \nRestart now?", "Language Change",MessageBoxButtons.OKCancel,MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.OK)
             {
                 Properties.Settings.Default.Language = "de";
                 Properties.Settings.Default.Save();
@@ -216,7 +218,7 @@ namespace FFXIV_TexTools2
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Main] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Main] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
         }
@@ -261,7 +263,7 @@ namespace FFXIV_TexTools2
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Main] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Main] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
         }
@@ -335,11 +337,11 @@ namespace FFXIV_TexTools2
 
             if (!Helper.IsIndexLocked(true))
             {
-                if (MessageBox.Show("Starting over will:\n\n" +
+                if (FlexibleMessageBox.Show("Starting over will:\n\n" +
                     "Restore index files to their original state.\n" +
                     "Delete all mods and create new .dat files.\n" +
                     "Delete all .modlist file entries.\n\n" +
-                    "Do you want to start over?", "Start Over", MessageBoxButton.YesNo, MessageBoxImage.Information) == MessageBoxResult.Yes)
+                    "Do you want to start over?", "Start Over",MessageBoxButtons.YesNo,MessageBoxIcon.Information) == System.Windows.Forms.DialogResult.Yes)
                 {
 
                     RevertAll();

--- a/FFXIV_TexTools2/ViewModel/ListViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ListViewModel.cs
@@ -25,6 +25,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -52,7 +53,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception e)
             {
-                MessageBox.Show("[VM] Error Accessing .modlist File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[VM] Error Accessing .modlist File \n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
         }

--- a/FFXIV_TexTools2/ViewModel/MainViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/MainViewModel.cs
@@ -30,8 +30,11 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Xml;
+using MessageBox = System.Windows.Forms.MessageBox;
+using TreeNode = FFXIV_TexTools2.Model.TreeNode;
 
 namespace FFXIV_TexTools2.ViewModel
 {
@@ -95,7 +98,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch(Exception e)
             {
-                MessageBox.Show("Could not find sqpack folder in game directory.\nDirectory: " + Properties.Settings.Default.FFXIV_Directory + "\n\nError: " + e.Message, "Version Check Error", MessageBoxButton.OK, MessageBoxImage.None);
+               FlexibleMessageBox.Show("Could not find sqpack folder in game directory.\nDirectory: " + Properties.Settings.Default.FFXIV_Directory + "\n\nError: " + e.Message, "Version Check Error",MessageBoxButtons.OK,MessageBoxIcon.None);
             }
 
             try
@@ -105,7 +108,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch(Exception e)
             {
-                MessageBox.Show("Could not determine FFXIV Version.\nData read: " + versionFile[0] + "\n\nError: " + e.Message, "Version Check Error", MessageBoxButton.OK, MessageBoxImage.None);
+               FlexibleMessageBox.Show("Could not determine FFXIV Version.\nData read: " + versionFile[0] + "\n\nError: " + e.Message, "Version Check Error",MessageBoxButtons.OK,MessageBoxIcon.None);
 
             }
 
@@ -116,8 +119,8 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch
             {
-                MessageBox.Show("TexTools was unable to read Index Backups Directory setting\n\n" +
-                    "The following default will be used:\n" + indexBackupDir, "Settings Read Error", MessageBoxButton.OK, MessageBoxImage.Error);
+               FlexibleMessageBox.Show("TexTools was unable to read Index Backups Directory setting\n\n" +
+                    "The following default will be used:\n" + indexBackupDir, "Settings Read Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             if (indexBackupDir.Equals(""))
@@ -142,7 +145,7 @@ namespace FFXIV_TexTools2.ViewModel
 
                 var backupMessage = "No index file backups were detected. \nWould you like to create a backup now? \n\nWarning:\nIn order to create a clean backup, all active modifications will be set to disabled, they will have to be re-enabled manually.";
 
-                if (MessageBox.Show(backupMessage, "Create Backup", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
+                if (MessageBox.Show(backupMessage, "Create Backup",MessageBoxButtons.YesNo,MessageBoxIcon.Error) == DialogResult.Yes)
                 {
                     Directory.CreateDirectory(indexBackupDir);
 
@@ -159,13 +162,13 @@ namespace FFXIV_TexTools2.ViewModel
                             }
                             catch (Exception e)
                             {
-                                MessageBox.Show("There was an issue creating backup files. \n" + e.Message, "Backup Error", MessageBoxButton.OK, MessageBoxImage.None);
+                               FlexibleMessageBox.Show("There was an issue creating backup files. \n" + e.Message, "Backup Error",MessageBoxButtons.OK,MessageBoxIcon.None);
                             }
                         }
                         else
                         {
-                            MessageBox.Show("There are still modified offsets in the index files, disable all mods and reopen TexTools to try again.\n\n" +
-                                "If this issue persits, obtain new index backups to place in the index_backups folder. (TexTools Discord is a good place to ask)", "Backup Error", MessageBoxButton.OK, MessageBoxImage.None);
+                           FlexibleMessageBox.Show("There are still modified offsets in the index files, disable all mods and reopen TexTools to try again.\n\n" +
+                                "If this issue persits, obtain new index backups to place in the index_backups folder. (TexTools Discord is a good place to ask)", "Backup Error",MessageBoxButtons.OK,MessageBoxIcon.None);
                         }
                     }
                 }
@@ -184,7 +187,7 @@ namespace FFXIV_TexTools2.ViewModel
                 {
                     Helper.FixIndex();
                     var backupMessage = "A newer version of FFXIV was detected. \nWould you like to create a new backup of your index files now? (Recommended) \n\nWarning:\nIn order to create a clean backup, all active modifications will be set to disabled, they will have to be re-enabled manually.";
-                    if (MessageBox.Show(backupMessage, "Create Backup", MessageBoxButton.YesNo, MessageBoxImage.Error) == MessageBoxResult.Yes)
+                    if (MessageBox.Show(backupMessage, "Create Backup",MessageBoxButtons.YesNo,MessageBoxIcon.Error) == DialogResult.Yes)
                     {
                         if (!Helper.IsIndexLocked(true))
                         {
@@ -204,13 +207,13 @@ namespace FFXIV_TexTools2.ViewModel
                                 }
                                 catch (Exception e)
                                 {
-                                    MessageBox.Show("There was an issue creating backup files. \n" + e.Message, "Backup Error", MessageBoxButton.OK, MessageBoxImage.None);
+                                   FlexibleMessageBox.Show("There was an issue creating backup files. \n" + e.Message, "Backup Error",MessageBoxButtons.OK,MessageBoxIcon.None);
                                 }
                             }
                             else
                             {
-                                MessageBox.Show("There are still modified offsets in the index files, disable all mods and reopen TexTools to try again.\n\n" +
-                                    "If this issue persits, obtain new index backups to place in the index_backups folder. (TexTools Discord is a good place to ask)", "Backup Error", MessageBoxButton.OK, MessageBoxImage.None);
+                               FlexibleMessageBox.Show("There are still modified offsets in the index files, disable all mods and reopen TexTools to try again.\n\n" +
+                                    "If this issue persits, obtain new index backups to place in the index_backups folder. (TexTools Discord is a good place to ask)", "Backup Error",MessageBoxButtons.OK,MessageBoxIcon.None);
                             }
                         }
                     }
@@ -253,14 +256,14 @@ namespace FFXIV_TexTools2.ViewModel
 
                     File.Delete(oldModListDir);
 
-                    MessageBox.Show("TexTools discovered an old modlist in the ffxiv directory. \n\n" +
-                        "A new modlist (TexTools.modlist) with the same data has been created and is located in the TexTools folder. ", "ModList Change.", MessageBoxButton.OK, MessageBoxImage.Information);
+                   FlexibleMessageBox.Show("TexTools discovered an old modlist in the ffxiv directory. \n\n" +
+                        "A new modlist (TexTools.modlist) with the same data has been created and is located in the TexTools folder. ", "ModList Change.",MessageBoxButtons.OK,MessageBoxIcon.Information);
                 }
             }
             catch(Exception e)
             {
-                MessageBox.Show("There was an error converting the old modlist.  \n\n" +
-                 "A new modlist will be created, you may remove the old modlist from the ffxiv folder. \n\n" + e.Message, "ModList Error", MessageBoxButton.OK, MessageBoxImage.Error);
+               FlexibleMessageBox.Show("There was an error converting the old modlist.  \n\n" +
+                 "A new modlist will be created, you may remove the old modlist from the ffxiv folder. \n\n" + e.Message, "ModList Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
 
@@ -299,7 +302,7 @@ namespace FFXIV_TexTools2.ViewModel
                 {
                     if (Directory.Exists(i))
                     {
-                        if (MessageBox.Show("FFXIV install directory found at \n\n" + i + "\n\nUse this directory? ", "Install Directory Found", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                        if (FlexibleMessageBox.Show("FFXIV install directory found at \n\n" + i + "\n\nUse this directory? ", "Install Directory Found",MessageBoxButtons.YesNo,MessageBoxIcon.Question) == DialogResult.Yes)
                         {
                             installDirectory = i;
                             Properties.Settings.Default.FFXIV_Directory = installDirectory;
@@ -312,7 +315,7 @@ namespace FFXIV_TexTools2.ViewModel
 
                 if (installDirectory.Equals(""))
                 {
-                    if (MessageBox.Show("Please locate the following directory. \n\n .../FINAL FANTASY XIV - A Realm Reborn/game/sqpack/ffxiv", "Install Directory Not Found", MessageBoxButton.OK, MessageBoxImage.Question) == MessageBoxResult.OK)
+                    if (FlexibleMessageBox.Show("Please locate the following directory. \n\n .../FINAL FANTASY XIV - A Realm Reborn/game/sqpack/ffxiv", "Install Directory Not Found",MessageBoxButtons.OK,MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.OK)
                     {
                         while (!installDirectory.Contains("ffxiv"))
                         {
@@ -411,7 +414,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception ex)
             {
-                MessageBox.Show("There was an issue checking for updates. \n" + ex.Message, "Updater Error", MessageBoxButton.OK, MessageBoxImage.None);
+               FlexibleMessageBox.Show("There was an issue checking for updates. \n" + ex.Message, "Updater Error",MessageBoxButtons.OK,MessageBoxIcon.None);
             }
         }
 
@@ -644,7 +647,7 @@ namespace FFXIV_TexTools2.ViewModel
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[Main] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Main] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
             }
         }
@@ -701,7 +704,7 @@ namespace FFXIV_TexTools2.ViewModel
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("[Main] Error checking index values for backup. \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Main] Error checking index values for backup. \n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 try
@@ -744,7 +747,7 @@ namespace FFXIV_TexTools2.ViewModel
                 }
                 catch (Exception e)
                 {
-                    MessageBox.Show("[Main] Error checking index2 values for backup. \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[Main] Error checking index2 values for backup. \n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
 
                 }
             }

--- a/FFXIV_TexTools2/ViewModel/ModListTVViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModListTVViewModel.cs
@@ -22,6 +22,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace FFXIV_TexTools2.ViewModel
 {
@@ -61,7 +62,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception e)
             {
-                MessageBox.Show("[VM] Error Accessing .modlist File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[VM] Error Accessing .modlist File \n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
 

--- a/FFXIV_TexTools2/ViewModel/ModListViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModListViewModel.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
+using System.Windows.Forms;
 
 namespace FFXIV_TexTools2.ViewModel
 {
@@ -47,7 +48,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception e)
             {
-                MessageBox.Show("[VM] Error Accessing .modlist File \n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[VM] Error Accessing .modlist File \n" + e.Message, "Error", MessageBoxButtons.OK,MessageBoxIcon.Error);
             }
 
 

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -28,6 +28,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
@@ -197,7 +198,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Main] Model Error \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Main] Model Error \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Debug.WriteLine(ex.StackTrace);
             }
         }
@@ -309,7 +310,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Collada] Error saving .dae File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Collada] Error saving .dae File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Debug.WriteLine(ex.StackTrace);
             }
 
@@ -373,7 +374,7 @@ namespace FFXIV_TexTools2.ViewModel
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[MVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[MVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 if (modEntry != null)
@@ -808,7 +809,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[Main] part 3D Error \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[Main] part 3D Error \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 Debug.WriteLine(ex.StackTrace);
             }
         }
@@ -1108,7 +1109,7 @@ namespace FFXIV_TexTools2.ViewModel
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[MVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[MVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 if (inModList)

--- a/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
@@ -30,9 +30,11 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
+
 
 namespace FFXIV_TexTools2.ViewModel
 {
@@ -474,7 +476,7 @@ namespace FFXIV_TexTools2.ViewModel
                 }
                 catch (Exception ex)
                 {
-                    MessageBox.Show("[TVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[TVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
 
                 if (modEntry != null)
@@ -1008,7 +1010,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch (Exception ex)
             {
-                MessageBox.Show("[TVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                FlexibleMessageBox.Show("[TVM] Error Accessing .modlist File \n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
             if (inModList)
@@ -1275,7 +1277,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             catch(Exception e)
             {
-                    MessageBox.Show("[TVM] There was an error updating the image.\n" + e.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    FlexibleMessageBox.Show("[TVM] There was an error updating the image.\n" + e.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
 
         }

--- a/FFXIV_TexTools2/Views/Directories.xaml.cs
+++ b/FFXIV_TexTools2/Views/Directories.xaml.cs
@@ -14,10 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using FFXIV_TexTools2.Helpers;
 using FolderSelect;
 using System.Diagnostics;
 using System.IO;
 using System.Windows;
+using System.Windows.Forms;
+using MessageBox = System.Windows.MessageBox;
 
 namespace FFXIV_TexTools2.Views
 {
@@ -72,7 +75,7 @@ namespace FFXIV_TexTools2.Views
             var result = folderSelect.ShowDialog();
             if (result)
             {
-                if (MessageBox.Show("Would you like to move the existing data to the new location?", "Move Data?", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                if (FlexibleMessageBox.Show("Would you like to move the existing data to the new location?", "Move Data?",MessageBoxButtons.YesNo,MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.Yes)
                 {
                     try
                     {
@@ -104,8 +107,8 @@ namespace FFXIV_TexTools2.Views
                 Properties.Settings.Default.Save_Directory = folderSelect.FileName + "/Saved";
                 Properties.Settings.Default.Save();
 
-                MessageBox.Show("Location of Saved folder changed.\n\n" +
-                    "New Location: " + folderSelect.FileName + "\\Saved", "New Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+               FlexibleMessageBox.Show("Location of Saved folder changed.\n\n" +
+                    "New Location: " + folderSelect.FileName + "\\Saved", "New Directory",MessageBoxButtons.OK,MessageBoxIcon.Information);
                 saveDir.Text = folderSelect.FileName + "\\Saved";
             }
         }
@@ -124,7 +127,7 @@ namespace FFXIV_TexTools2.Views
                 Properties.Settings.Default.IndexBackups_Directory = folderSelect.FileName + "\\Index_Backups";
                 Properties.Settings.Default.Save();
 
-                if (MessageBox.Show("Would you like to move the existing data to the new location?", "Move Data?", MessageBoxButton.YesNo, MessageBoxImage.Question) == MessageBoxResult.Yes)
+                if (FlexibleMessageBox.Show("Would you like to move the existing data to the new location?", "Move Data?",MessageBoxButtons.YesNo,MessageBoxIcon.Question) == System.Windows.Forms.DialogResult.Yes)
                 {
                     try
                     {
@@ -150,8 +153,8 @@ namespace FFXIV_TexTools2.Views
                     }
                 }
 
-                MessageBox.Show("Location of Index Backup folder changed.\n\n" +
-                    "New Location: " + folderSelect.FileName + "\\Index_Backups", "New Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+               FlexibleMessageBox.Show("Location of Index Backup folder changed.\n\n" +
+                    "New Location: " + folderSelect.FileName + "\\Index_Backups", "New Directory",MessageBoxButtons.OK,MessageBoxIcon.Information);
                 indexBackupsDir.Text = folderSelect.FileName + "\\Index_Backups";
             }
         }
@@ -182,8 +185,8 @@ namespace FFXIV_TexTools2.Views
                     File.Delete(oldModListLocation);
                 }
 
-                MessageBox.Show("Location of ModList file changed.\n\n" +
-                    "New Location: " + fullLoc, "New Directory", MessageBoxButton.OK, MessageBoxImage.Information);
+               FlexibleMessageBox.Show("Location of ModList file changed.\n\n" +
+                    "New Location: " + fullLoc, "New Directory",MessageBoxButtons.OK,MessageBoxIcon.Information);
                 modListDir.Text = fullLoc;
             }
         }


### PR DESCRIPTION
Current existing displays of MessageBox will not scale well with long error messages, causing the 'Yes/No' etc dialogues to end up off screen, which in turn results in an unclosable program.

FlexibleMessageBox adds support for scaling message boxes with scroll bars.

Source: https://www.codeproject.com/Articles/601900/FlexibleMessageBox-A-flexible-replacement-for-the

Thanks to JReichert for this useful class!