### PR TITLE
preserve-camera-settings: Saving of Camera Settings before Reloading

### DIFF
--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -1063,8 +1063,19 @@ namespace FFXIV_TexTools2.ViewModel
                     meshData.Add(mData);
                 }
 
+                // Preserve Camera settings before reset
+                var lookDir = CompositeVM.Camera.LookDirection;
+                var upDir = CompositeVM.Camera.UpDirection;
+                var pos = CompositeVM.Camera.Position;
+
+                // Reset 3d View for loading new model
                 CompositeVM = new Composite3DViewModel();
                 CompositeVM.UpdateModel(meshData, selectedItem);
+
+                // Re-apply original camera settings
+                CompositeVM.Camera.LookDirection = lookDir;
+                CompositeVM.Camera.UpDirection = upDir;
+                CompositeVM.Camera.Position = pos;
 
                 is3DLoaded = true;
 


### PR DESCRIPTION
When refreshing the 3d view by selecting a new model, camera settings were reset which made it difficult to compare one modal to another.

Camera settings should now persist during reload, which should make things easier for everyone :)