### PR TITLE
Fix null colorBmp when viewing an object that does not exist 

### DIFF
--- a/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
@@ -1045,6 +1045,11 @@ namespace FFXIV_TexTools2.ViewModel
 
                 TextureDimensions = "(4 x 16)";
 
+                if(colorBmp == null) 
+                {
+                    colorBmp = new Bitmap(4, 16);
+                }
+
                 alphaBitmap = Imaging.CreateBitmapSourceFromHBitmap(colorBmp.GetHbitmap(), IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
                 alphaBitmap.Freeze();
 


### PR DESCRIPTION
(like Miqo'te hair 104/109)

This raises an error that the debugger catches, but the release build covers up, as a result the user gets no feedback and if they don't notice that the normal is wrong they run the risk of trying to do operations on these hair that don't exist.

This change will initialize the colorBmp object if it was null and sets it to a 4x16 pixel bmp to match the hard coded display for when this happens.