### PR TITLE
1.9.8 Pull Request

### DIFF
--- a/FFXIV_TexTools2/App.config
+++ b/FFXIV_TexTools2/App.config
@@ -49,6 +49,9 @@
             <setting name="Etc_Color" serializeAs="String">
                 <value>#FF603913</value>
             </setting>
+          <setting name="BG_Color" serializeAs="String">
+            <value>#FF777777</value>
+          </setting>
         </FFXIV_TexTools2.Properties.Settings>
     </userSettings>
   <runtime>

--- a/FFXIV_TexTools2/FileTypes/MDL.cs
+++ b/FFXIV_TexTools2/FileTypes/MDL.cs
@@ -159,7 +159,7 @@ namespace FFXIV_TexTools2.Material
 
             using (BinaryReader br = new BinaryReader(new MemoryStream(MDLDatData.Item1)))
             {
-                // The size of the header + (size of the mesh information block (136 bytes) * the number of meshes) + padding
+                // The size of the header + (size of the mesh information block (136 bytes) * the meshes) + padding
                 br.BaseStream.Seek(64 + 136 * MDLDatData.Item2 + 4, SeekOrigin.Begin);
 
                 var modelStringCount = br.ReadInt32();
@@ -632,20 +632,6 @@ namespace FFXIV_TexTools2.Material
                 }
 
 
-                for (int i = 0; i < 3; i++)
-                {
-                    for (int j = 0; j < modelData.LoD[i].MeshCount; j++)
-                    {
-                        Mesh mesh = modelData.LoD[i].MeshList[j];
-                        for(int x = 0; x < mesh.IndexData.Count(); x++)
-                        {
-                            if (mesh.IndexData[x] != modelData.LoD[0].MeshList[j].IndexData[x])
-                            {
-                                //MessageBox.Show("asdf");
-                            }
-                        }
-                    }
-                }
 
                 int vertex = 0, coordinates = 0, normals = 0, tangents = 0, colors = 0, blendWeights = 0, blendIndices = 0;
 

--- a/FFXIV_TexTools2/FileTypes/ModelContainers/Mesh.cs
+++ b/FFXIV_TexTools2/FileTypes/ModelContainers/Mesh.cs
@@ -60,5 +60,10 @@ namespace FFXIV_TexTools2.Material.ModelMaterial
         /// True if mesh has a body texture, false otherwise.
         /// </summary>
         public bool IsBody { get; set; }
+
+        /// <summary>
+        /// Bone Set Index use by this mesh.
+        /// </summary>
+        public int BoneListIndex;
     }
 }

--- a/FFXIV_TexTools2/IO/ExdReader.cs
+++ b/FFXIV_TexTools2/IO/ExdReader.cs
@@ -1346,7 +1346,8 @@ namespace FFXIV_TexTools2.IO
 
                     int statusIconNum = BitConverter.ToUInt16(br.ReadBytes(2).Reverse().ToArray(), 0);
 
-                    br.ReadBytes(3);
+                    byte[] unknown = br.ReadBytes(2);
+                    byte iconCount = br.ReadByte();
 
                     int statusType = br.ReadByte();
 
@@ -1383,7 +1384,6 @@ namespace FFXIV_TexTools2.IO
                             item.ItemCategory = Strings.Status;
 
                             TreeNode itemNode = new TreeNode() { Name = item.ItemName, ItemData = item };
-
                             if (statusDict.ContainsKey(item.ItemSubCategory))
                             {
                                 statusDict[item.ItemSubCategory]._subNode.Add(itemNode);
@@ -1392,6 +1392,22 @@ namespace FFXIV_TexTools2.IO
                             {
                                 statusDict.Add(item.ItemSubCategory, new TreeNode() { Name = item.ItemSubCategory, _subNode = { itemNode } });
                             }
+
+                            if (iconCount > 1)
+                            {
+                                for(int c = 1; c < iconCount; c++)
+                                {
+                                    ItemData alternate = new ItemData();
+                                    alternate.Icon = (statusIconNum + c).ToString();
+                                    alternate.ItemSubCategory = item.ItemSubCategory;
+                                    alternate.ItemName = item.ItemName + "-" + (c+1).ToString();
+                                    alternate.ItemCategory = Strings.Status;
+
+                                    TreeNode alternateNode = new TreeNode() { Name = alternate.ItemName, ItemData = alternate };
+                                    statusDict[alternate.ItemSubCategory]._subNode.Add(alternateNode);
+                                }
+                            }
+
                         }
                     }
                 }

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -3151,8 +3151,15 @@ namespace FFXIV_TexTools2.IO
                     headerLength = 512;
                 }
 
-				//Header Length
-				datHeader.AddRange(BitConverter.GetBytes(headerLength));
+                // Sanity check - Not sure exactly when this runs past the header length,
+                // But somewhere in here it happens.
+                if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 96)
+                {
+                    headerLength = 1024;
+                }
+
+                    //Header Length
+                    datHeader.AddRange(BitConverter.GetBytes(headerLength));
 				//Data Type
 				datHeader.AddRange(BitConverter.GetBytes(3));
 				//Uncompressed Size

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -755,21 +755,67 @@ namespace FFXIV_TexTools2.IO
 
                                 /* Error Checking */
                                 int numVerts = mDict[c].vIndexList.Count / 3;
+                                int maxVert = mDict[c].vIndexList.Max();
+
                                 int numNormals = mDict[c].nIndexList.Count / 3;
+                                int maxNormal = mDict[c].nIndexList.Max();
 
                                 int numTexCoord = mDict[c].tcIndexList.Count / 3;
+                                int maxTexCoord = mDict[c].tcIndexList.Max();
+
                                 int numTexCoord2 = mDict[c].tc2IndexList.Count / 3;
+                                int maxTexCoord2 = mDict[c].tc2IndexList.Max();
+
+                                int numBinormals = mDict[c].bnIndexList.Count / 3;
+                                float maxBinormal = mDict[c].bnIndexList.Max();
 
                                 if (numVerts != numNormals // Normals are simple.
                                     || (numVerts != numTexCoord ) // Check if our coordinate count matches
                                     || (numVerts != numTexCoord2 && numTexCoord2 != 0)) // Check if our coordinate2 count matches
                                 {
-                                    FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinate entries do not match for \nMesh: " + i + " Part: " + j
+                                    FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinate entries do not match for:\nMesh: " + i + " Part: " + j
                                         + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import\n\nVertexCount: "
                                         + numVerts + "\nNormal Count:" + numNormals + "\nUV1 Coordinates: " + numTexCoord + "\nUV2 Coordinates: " + numTexCoord2 + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }
 
-						        cdDict[i].vertex.AddRange(mDict[c].vertex);
+                                if(numBinormals == 0)
+                                {
+                                    FlexibleMessageBox.Show("There were no Binormals in:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\nPlease make sure your OpenCollada Export settings are correct."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+                                if(maxVert > mDict[c].vertex.Count())
+                                {
+                                    FlexibleMessageBox.Show("The following mesh part references Vertices which do not exist in the file:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+                                if (maxNormal > mDict[c].normal.Count())
+                                {
+                                    FlexibleMessageBox.Show("The following mesh part references Normals which do not exist in the file:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+                                if (maxTexCoord > mDict[c].texCoord.Count())
+                                {
+                                    FlexibleMessageBox.Show("The following mesh part references UV1 Data which does not exist in the file:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+                                if (maxTexCoord2 > mDict[c].texCoord2.Count())
+                                {
+                                    FlexibleMessageBox.Show("The following mesh part references UV2 Data which does not exist in the file:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+
+                                cdDict[i].vertex.AddRange(mDict[c].vertex);
 						        cdDict[i].normal.AddRange(mDict[c].normal);
 						        cdDict[i].texCoord.AddRange(mDict[c].texCoord);
 						        cdDict[i].texCoord2.AddRange(mDict[c].texCoord2);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -481,6 +481,7 @@ namespace FFXIV_TexTools2.IO
 									                                "Full Name: " + atr + "\n\n" +
                                                                     "Delete or Rename the duplicate mesh part and try again.\n\n" +
 									                                "Error: " + e.Message, "ImportModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                            return;
                                         }
 
                                     }
@@ -753,17 +754,17 @@ namespace FFXIV_TexTools2.IO
                                 }
 
                                 /* Error Checking */
-                                int numVerts = mDict[c].vertex.Count / 3;
-                                int numNormals = mDict[c].normal.Count / 3;
+                                int numVerts = mDict[c].vIndexList.Count / 3;
+                                int numNormals = mDict[c].nIndexList.Count / 3;
 
-                                int numTexCoord = mDict[c].texCoord.Count / tcStride;
-                                int numTexCoord2 = mDict[c].texCoord2.Count / tcStride;
+                                int numTexCoord = mDict[c].tcIndexList.Count / tcStride;
+                                int numTexCoord2 = mDict[c].tc2IndexList.Count / tcStride;
 
                                 if (numVerts != numNormals // Normals are simple.
                                     || (numVerts != numTexCoord ) // Check if our coordinate count matches
                                     || (numVerts != numTexCoord2 && numTexCoord2 != 0)) // Check if our coordinate2 count matches
                                 {
-                                    FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinates do not match for \nMesh: " + i + " Part: " + j
+                                    FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinate entries do not match for \nMesh: " + i + " Part: " + j
                                         + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import\n\nVertexCount: "
                                         + numVerts + "\nNormal Count:" + numNormals + "\nUV1 Coordinates: " + numTexCoord + "\nUV2 Coordinates: " + numTexCoord2 + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -758,7 +758,7 @@ namespace FFXIV_TexTools2.IO
 
                                 if (numVerts != numNormals // Normals are simple.
                                     || (numVerts != numTexCoord ) // Check if our coordinate count matches
-                                    || (numVerts != numTexCoord2 && numTexCoord != 0)) // Check if our coordinate2 count matches
+                                    || (numVerts != numTexCoord2 && numTexCoord2 != 0)) // Check if our coordinate2 count matches
                                 {
                                     FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinates do not match for \nMesh: " + i + " Part: " + j
                                         + "\n\nThis has a strong chance of either crashing TexTools or causing other errors in the import\n\nVertexCount: "
@@ -3145,7 +3145,8 @@ namespace FFXIV_TexTools2.IO
 
                 if (blockCount > 24)
                 {
-                    // Base size at count * 24 is 256
+                    // Base size at count * 24 is technically only 252
+                    // but having a 4 byte safety buffer is good.
                     int remainingBlocks = blockCount - 24;
                     int bytesUsed = remainingBlocks * 2;
                     int extensionsNeeded = (bytesUsed / 128) + 1;
@@ -3153,8 +3154,8 @@ namespace FFXIV_TexTools2.IO
                     headerLength = newSize;
                 }
 
-                    //Header Length
-                    datHeader.AddRange(BitConverter.GetBytes(headerLength));
+                //Header Length
+                datHeader.AddRange(BitConverter.GetBytes(headerLength));
 				//Data Type
 				datHeader.AddRange(BitConverter.GetBytes(3));
 				//Uncompressed Size

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -755,19 +755,19 @@ namespace FFXIV_TexTools2.IO
 
                                 /* Error Checking */
                                 int numVerts = mDict[c].vIndexList.Count / 3;
-                                int maxVert = mDict[c].vIndexList.Max();
+                                int maxVert = numVerts == 0 ? 0 : mDict[c].vIndexList.Count();
 
                                 int numNormals = mDict[c].nIndexList.Count / 3;
-                                int maxNormal = mDict[c].nIndexList.Max();
+                                int maxNormal = numNormals == 0 ? 0 : mDict[c].nIndexList.Count();
 
                                 int numTexCoord = mDict[c].tcIndexList.Count / 3;
-                                int maxTexCoord = mDict[c].tcIndexList.Max();
+                                int maxTexCoord = numTexCoord == 0 ? 0 : mDict[c].tcIndexList.Count();
 
                                 int numTexCoord2 = mDict[c].tc2IndexList.Count / 3;
-                                int maxTexCoord2 = mDict[c].tc2IndexList.Max();
+                                int maxTexCoord2 = numTexCoord2 == 0 ? 0 : mDict[c].tc2IndexList.Count();
 
                                 int numBinormals = mDict[c].bnIndexList.Count / 3;
-                                float maxBinormal = mDict[c].bnIndexList.Max();
+                                int maxBinormal = numBinormals == 0 ? 0 : mDict[c].bnIndexList.Count();
 
                                 if (numVerts != numNormals // Normals are simple.
                                     || (numVerts != numTexCoord ) // Check if our coordinate count matches
@@ -806,6 +806,7 @@ namespace FFXIV_TexTools2.IO
                                         + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
                                         + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }
+
 
                                 if (maxTexCoord2 > mDict[c].texCoord2.Count())
                                 {

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -764,7 +764,7 @@ namespace FFXIV_TexTools2.IO
                                     || (numVerts != numTexCoord2 && numTexCoord2 != 0)) // Check if our coordinate2 count matches
                                 {
                                     FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinates do not match for \nMesh: " + i + " Part: " + j
-                                        + "\n\nThis has a strong chance of either crashing TexTools or causing other errors in the import\n\nVertexCount: "
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import\n\nVertexCount: "
                                         + numVerts + "\nNormal Count:" + numNormals + "\nUV1 Coordinates: " + numTexCoord + "\nUV2 Coordinates: " + numTexCoord2 + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }
 

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -3141,21 +3141,16 @@ namespace FFXIV_TexTools2.IO
                 #region Header Generation
                 int headerLength = 256;
 
-                if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 24)
-                {
-                    headerLength = 384;
-                }
+                int blockCount = (compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count);
 
-                if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 48)
+                if (blockCount > 24)
                 {
-                    headerLength = 512;
-                }
-
-                // Sanity check - Not sure exactly when this runs past the header length,
-                // But somewhere in here it happens.
-                if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 96)
-                {
-                    headerLength = 1024;
+                    // Base size at count * 24 is 256
+                    int remainingBlocks = blockCount - 24;
+                    int bytesUsed = remainingBlocks * 2;
+                    int extensionsNeeded = (bytesUsed / 128) + 1;
+                    int newSize = 256 + (extensionsNeeded * 128);
+                    headerLength = newSize;
                 }
 
                     //Header Length
@@ -3386,6 +3381,12 @@ namespace FFXIV_TexTools2.IO
                 }
 
                 //Rest of header
+                if(datHeader.Count > headerLength)
+                {
+                    FlexibleMessageBox.Show("Model Size/Header exceeded allowed size/length.\n\n" +
+                         "Please reduce model complexity and try again.\n\nThe import has been cancelled.", "ImportModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    return;
+                }
                 if (datHeader.Count != headerLength)
 				{
 					var headerEnd = headerLength - (datHeader.Count % headerLength);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -453,8 +453,11 @@ namespace FFXIV_TexTools2.IO
                                             if (meshNum > 0 && !pDict.ContainsKey(meshNum))
                                             {
                                                 for (int l = 0; l < 3; l++) {
-                                                    cdDict.Add(meshNum, new ColladaData());
-                                                    pDict.Add(meshNum, new Dictionary<int, ColladaData>());
+                                                    if (l == 0)
+                                                    {
+                                                        cdDict.Add(meshNum, new ColladaData());
+                                                        pDict.Add(meshNum, new Dictionary<int, ColladaData>());
+                                                    }
 
                                                     var mesh = new Mesh();
                                                     var newPart = new MeshPart();

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -757,8 +757,8 @@ namespace FFXIV_TexTools2.IO
                                 int numVerts = mDict[c].vIndexList.Count / 3;
                                 int numNormals = mDict[c].nIndexList.Count / 3;
 
-                                int numTexCoord = mDict[c].tcIndexList.Count / tcStride;
-                                int numTexCoord2 = mDict[c].tc2IndexList.Count / tcStride;
+                                int numTexCoord = mDict[c].tcIndexList.Count / 3;
+                                int numTexCoord2 = mDict[c].tc2IndexList.Count / 3;
 
                                 if (numVerts != numNormals // Normals are simple.
                                     || (numVerts != numTexCoord ) // Check if our coordinate count matches

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -742,29 +742,28 @@ namespace FFXIV_TexTools2.IO
 						        {
 						            cdDict[i].partsDict.Add(c, 0);
 						            c++;
-						        }
+                                }
+
+                                if (mDict[c].texCoord2.Count < 1 && indStride == 6)
+                                {
+                                    indStride = 4;
+                                }
 
                                 /* Error Checking */
                                 int numVerts = mDict[c].vertex.Count / 3;
                                 int numNormals = mDict[c].normal.Count / 3;
-                                int numTexCoord = mDict[c].texCoord.Count / 2;
-                                int numTexCoord2 = mDict[c].texCoord2.Count / 2;
-                                if (numVerts != numNormals || numVerts != numTexCoord || (numVerts != numTexCoord2 && numTexCoord != 0))
+
+                                int numTexCoord = mDict[c].texCoord.Count / tcStride;
+                                int numTexCoord2 = mDict[c].texCoord2.Count / tcStride;
+
+                                if (numVerts != numNormals // Normals are simple.
+                                    || (numVerts != numTexCoord ) // Check if our coordinate count matches
+                                    || (numVerts != numTexCoord2 && numTexCoord != 0)) // Check if our coordinate2 count matches
                                 {
                                     FlexibleMessageBox.Show("Number of Vertices/Normals/Texture Coordinates do not match for \nMesh: " + i + " Part: " + j
                                         + "\n\nThis has a strong chance of either crashing TexTools or causing other errors in the import\n\nVertexCount: "
                                         + numVerts + "\nNormal Count:" + numNormals + "\n UV1 Coordinates: " + numTexCoord + "\nUV2 Coordinates: " + numTexCoord2 + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }
-
-
-
-
-
-
-                                if (mDict[c].texCoord2.Count < 1 && indStride == 6)
-						        {
-						            indStride = 4;
-						        }
 
 						        cdDict[i].vertex.AddRange(mDict[c].vertex);
 						        cdDict[i].normal.AddRange(mDict[c].normal);
@@ -3142,10 +3141,15 @@ namespace FFXIV_TexTools2.IO
                 #region Header Generation
                 int headerLength = 256;
 
-				if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 24)
-				{
-					headerLength = 384;
-				}
+                if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 24)
+                {
+                    headerLength = 384;
+                }
+
+                if ((compMeshSizes.Count + modelDataParts + 3 + compIndexSizes.Count) > 48)
+                {
+                    headerLength = 512;
+                }
 
 				//Header Length
 				datHeader.AddRange(BitConverter.GetBytes(headerLength));
@@ -3375,7 +3379,7 @@ namespace FFXIV_TexTools2.IO
                 }
 
                 //Rest of header
-                if (datHeader.Count != 256 && datHeader.Count != 384)
+                if (datHeader.Count != headerLength)
 				{
 					var headerEnd = headerLength - (datHeader.Count % headerLength);
 					datHeader.AddRange(new byte[headerEnd]);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -755,19 +755,19 @@ namespace FFXIV_TexTools2.IO
 
                                 /* Error Checking */
                                 int numVerts = mDict[c].vIndexList.Count / 3;
-                                int maxVert = numVerts == 0 ? 0 : mDict[c].vIndexList.Count();
+                                int maxVert = numVerts == 0 ? 0 : mDict[c].vIndexList.Max();
 
                                 int numNormals = mDict[c].nIndexList.Count / 3;
-                                int maxNormal = numNormals == 0 ? 0 : mDict[c].nIndexList.Count();
+                                int maxNormal = numNormals == 0 ? 0 : mDict[c].nIndexList.Max();
 
                                 int numTexCoord = mDict[c].tcIndexList.Count / 3;
-                                int maxTexCoord = numTexCoord == 0 ? 0 : mDict[c].tcIndexList.Count();
+                                int maxTexCoord = numTexCoord == 0 ? 0 : mDict[c].tcIndexList.Max();
 
                                 int numTexCoord2 = mDict[c].tc2IndexList.Count / 3;
-                                int maxTexCoord2 = numTexCoord2 == 0 ? 0 : mDict[c].tc2IndexList.Count();
+                                int maxTexCoord2 = numTexCoord2 == 0 ? 0 : mDict[c].tc2IndexList.Max();
 
                                 int numBinormals = mDict[c].bnIndexList.Count / 3;
-                                int maxBinormal = numBinormals == 0 ? 0 : mDict[c].bnIndexList.Count();
+                                int maxBinormal = numBinormals == 0 ? 0 : mDict[c].bnIndexList.Max();
 
                                 if (numVerts != numNormals // Normals are simple.
                                     || (numVerts != numTexCoord ) // Check if our coordinate count matches

--- a/FFXIV_TexTools2/MainWindow.xaml.cs
+++ b/FFXIV_TexTools2/MainWindow.xaml.cs
@@ -149,7 +149,8 @@ namespace FFXIV_TexTools2
 
         private void Menu_ModList_Click(object sender, RoutedEventArgs e)
         {
-            ModList ml = new ModList();
+            
+            ModList ml = new ModList(this.mViewModel.ModelVM, this.mViewModel.TextureVM);
             ml.Owner = this;
             ml.Show();
         }

--- a/FFXIV_TexTools2/Model/ImportSettings.cs
+++ b/FFXIV_TexTools2/Model/ImportSettings.cs
@@ -9,7 +9,8 @@ namespace FFXIV_TexTools2.Model
     public class ImportSettings
     {
         public string path;
-        public bool Fix;
-        public bool Disable;
+        public bool Fix = false;
+        public bool Disable = false;
+        public bool UseOriginalBones = false;
     }
 }

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.7.0")]
+[assembly: AssemblyFileVersion("1.9.8.0")]

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.6.0")]
+[assembly: AssemblyFileVersion("1.9.7.0")]

--- a/FFXIV_TexTools2/Properties/Settings.Designer.cs
+++ b/FFXIV_TexTools2/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace FFXIV_TexTools2.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.8.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -93,8 +93,8 @@ namespace FFXIV_TexTools2.Properties {
             set {
                 this["Modlist_Directory"] = value;
             }
-        }   
-
+        }
+        
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
@@ -176,6 +176,18 @@ namespace FFXIV_TexTools2.Properties {
             }
             set {
                 this["Etc_Color"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("#FF777777")]
+        public string BG_Color {
+            get {
+                return ((string)(this["BG_Color"]));
+            }
+            set {
+                this["BG_Color"] = value;
             }
         }
     }

--- a/FFXIV_TexTools2/Properties/Settings.settings
+++ b/FFXIV_TexTools2/Properties/Settings.settings
@@ -41,5 +41,8 @@
     <Setting Name="Etc_Color" Type="System.String" Scope="User">
       <Value Profile="(Default)">#FF603913</Value>
     </Setting>
+    <Setting Name="BG_Color" Type="System.String" Scope="User">
+      <Value Profile="(Default)">#FF777777</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFXIV_TexTools2/ViewModel/Composite3DViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/Composite3DViewModel.cs
@@ -55,6 +55,10 @@ namespace FFXIV_TexTools2.ViewModel
 
         public int CurrentSS { get { return currentSS; } set { currentSS = value; NotifyPropertyChanged("CurrentSS"); } }
 
+        public bool IsDead()
+        {
+            return disposed || disposing;
+        }
 
         bool second = false;
         bool disposed = false;

--- a/FFXIV_TexTools2/ViewModel/Composite3DViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/Composite3DViewModel.cs
@@ -74,8 +74,16 @@ namespace FFXIV_TexTools2.ViewModel
             EffectsManager = new CustomEffectsManager(RenderTechniquesManager);
 
             this.Camera = new PerspectiveCamera();
+            string substr = Properties.Settings.Default.BG_Color.Substring(3, 2);
+            int red = int.Parse(substr, System.Globalization.NumberStyles.HexNumber);
 
-            BackgroundColor = Color.Gray;
+            substr = Properties.Settings.Default.BG_Color.Substring(5, 2);
+            int green = int.Parse(substr, System.Globalization.NumberStyles.HexNumber);
+
+            substr = Properties.Settings.Default.BG_Color.Substring(7, 2);
+            int blue = int.Parse(substr, System.Globalization.NumberStyles.HexNumber);
+
+            BackgroundColor = new Color4(red / 255f, green / 255f, blue / 255f, 1.0f);
             this.AmbientLightColor = new Color4(0.1f, 0.1f, 0.1f, 1.0f);
 
             this.Light1Direction = new Vector3(0, 0, -1f);
@@ -128,10 +136,17 @@ namespace FFXIV_TexTools2.ViewModel
             mg.Colors = mData[m].Mesh.VertexColors;
             mg.Tangents = new HelixToolkit.Wpf.SharpDX.Core.Vector3Collection();
 
+
+            var indexMax = 0;
+            for (int i = 0; i < mg.Indices.Count; i++)
+            {
+                if (mg.Indices.Count > indexMax)
+                    indexMax = mg.Indices[i];
+            }
             try
             {
                 MeshBuilder.ComputeTangents(mg);
-            } catch
+            } catch (Exception e)
             {
                 return null;
             }

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -952,8 +952,14 @@ namespace FFXIV_TexTools2.ViewModel
 
                         bool isBody = false;
                         bool isFace = false;
-
-                        MTRLData mtrlData = MTRL3D(i);
+                        MTRLData mtrlData;
+                        try
+                        {
+                            mtrlData = MTRL3D(i);
+                        } catch(Exception e)
+                        {
+                            continue;
+                        }
 
                         if (selectedCategory.Equals(Strings.Character))
                         {

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -90,6 +90,11 @@ namespace FFXIV_TexTools2.ViewModel
             CompositeVM = new Composite3DViewModel();
         }
 
+        public void ReloadModel()
+        {
+            UpdateModel(selectedItem, selectedCategory);
+        }
+
         public void UpdateModel(ItemData item, string category)
         {
             CompositeVM.Dispose();
@@ -294,6 +299,7 @@ namespace FFXIV_TexTools2.ViewModel
         private void SetLighting(object obj)
         {
             CompositeVM.Lighting();
+
         }
 
         /// <summary>
@@ -579,7 +585,7 @@ namespace FFXIV_TexTools2.ViewModel
 
                         if (selectedItem.ItemName.Equals(Strings.Body))
                         {
-                            break;
+                            //break;
                         }
                     }
                 }

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -1011,7 +1011,8 @@ namespace FFXIV_TexTools2.ViewModel
                             {
                                 normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
 
-                                if (materialStrings[i].Contains("_fac_"))
+                                
+                                if (mtrlData.MTRLPath.Contains("_fac_"))
                                 {
                                     specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
                                     diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -95,6 +95,7 @@ namespace FFXIV_TexTools2.ViewModel
             UpdateModel(selectedItem, selectedCategory);
         }
 
+
         public void UpdateModel(ItemData item, string category)
         {
             CompositeVM.Dispose();
@@ -520,87 +521,93 @@ namespace FFXIV_TexTools2.ViewModel
         /// </summary>
         private void RaceComboBoxChanged()
         {
-            is3DLoaded = false;
+            try
+            {
+                is3DLoaded = false;
 
-            if (CompositeVM != null && !disposing)
-            {
-                disposing = true;
-                CompositeVM.Dispose();
-            }
-
-            List<ComboBoxInfo> cbi = new List<ComboBoxInfo>();
-            string categoryType = Helper.GetCategoryType(selectedCategory);
-            string MDLFolder = "";
-
-            if (categoryType.Equals("weapon"))
-            {
-                cbi.Add(new ComboBoxInfo() { Name = selectedItem.PrimaryModelBody, ID = selectedItem.PrimaryModelBody, IsNum = false });
-            }
-            else if (categoryType.Equals("food"))
-            {
-                cbi.Add(new ComboBoxInfo() { Name = selectedItem.PrimaryModelBody, ID = selectedItem.PrimaryModelBody, IsNum = false });
-            }
-            else if (categoryType.Equals("accessory"))
-            {
-                cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });
-            }
-            else if (categoryType.Equals("character"))
-            {
-                if (selectedItem.ItemName.Equals(Strings.Body))
+                if (CompositeVM != null && !disposing)
                 {
-                    MDLFolder = string.Format(Strings.BodyMDLFolder, SelectedRace.ID, "{0}");
+                    disposing = true;
+                    CompositeVM.Dispose();
                 }
-                else if (selectedItem.ItemName.Equals(Strings.Face))
-                {
-                    MDLFolder = string.Format(Strings.FaceMDLFolder, SelectedRace.ID, "{0}");
-                }
-                else if (selectedItem.ItemName.Equals(Strings.Hair))
-                {
-                    MDLFolder = string.Format(Strings.HairMDLFolder, SelectedRace.ID, "{0}");
-                }
-                else if (selectedItem.ItemName.Equals(Strings.Tail))
-                {
-                    MDLFolder = string.Format(Strings.TailMDLFolder, SelectedRace.ID, "{0}");
-                }
-            }
-            else if (categoryType.Equals("monster"))
-            {
-                cbi.Add(new ComboBoxInfo() { Name = selectedItem.PrimaryModelBody, ID = selectedItem.PrimaryModelBody, IsNum = false });
-            }
-            else
-            {
-                cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });
-            }
 
+                List<ComboBoxInfo> cbi = new List<ComboBoxInfo>();
+                string categoryType = Helper.GetCategoryType(selectedCategory);
+                string MDLFolder = "";
 
-            if (categoryType.Equals("character"))
-            {
-                for (int i = 0; i < 250; i++)
+                if (categoryType.Equals("weapon"))
                 {
-                    string folder = String.Format(MDLFolder, i.ToString().PadLeft(4, '0'));
-
-                    if (Helper.FolderExists(FFCRC.GetHash(folder), Strings.ItemsDat))
+                    cbi.Add(new ComboBoxInfo() { Name = selectedItem.PrimaryModelBody, ID = selectedItem.PrimaryModelBody, IsNum = false });
+                }
+                else if (categoryType.Equals("food"))
+                {
+                    cbi.Add(new ComboBoxInfo() { Name = selectedItem.PrimaryModelBody, ID = selectedItem.PrimaryModelBody, IsNum = false });
+                }
+                else if (categoryType.Equals("accessory"))
+                {
+                    cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });
+                }
+                else if (categoryType.Equals("character"))
+                {
+                    if (selectedItem.ItemName.Equals(Strings.Body))
                     {
-                        cbi.Add(new ComboBoxInfo() { Name = i.ToString(), ID = i.ToString(), IsNum = true });
+                        MDLFolder = string.Format(Strings.BodyMDLFolder, SelectedRace.ID, "{0}");
+                    }
+                    else if (selectedItem.ItemName.Equals(Strings.Face))
+                    {
+                        MDLFolder = string.Format(Strings.FaceMDLFolder, SelectedRace.ID, "{0}");
+                    }
+                    else if (selectedItem.ItemName.Equals(Strings.Hair))
+                    {
+                        MDLFolder = string.Format(Strings.HairMDLFolder, SelectedRace.ID, "{0}");
+                    }
+                    else if (selectedItem.ItemName.Equals(Strings.Tail))
+                    {
+                        MDLFolder = string.Format(Strings.TailMDLFolder, SelectedRace.ID, "{0}");
+                    }
+                }
+                else if (categoryType.Equals("monster"))
+                {
+                    cbi.Add(new ComboBoxInfo() { Name = selectedItem.PrimaryModelBody, ID = selectedItem.PrimaryModelBody, IsNum = false });
+                }
+                else
+                {
+                    cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });
+                }
 
-                        if (selectedItem.ItemName.Equals(Strings.Body))
+
+                if (categoryType.Equals("character"))
+                {
+                    for (int i = 0; i < 250; i++)
+                    {
+                        string folder = String.Format(MDLFolder, i.ToString().PadLeft(4, '0'));
+
+                        if (Helper.FolderExists(FFCRC.GetHash(folder), Strings.ItemsDat))
                         {
-                            //break;
+                            cbi.Add(new ComboBoxInfo() { Name = i.ToString(), ID = i.ToString(), IsNum = true });
+
+                            if (selectedItem.ItemName.Equals(Strings.Body))
+                            {
+                                //break;
+                            }
                         }
                     }
                 }
-            }
 
-            BodyComboBox = new ObservableCollection<ComboBoxInfo>(cbi);
-            BodyIndex = 0;
+                BodyComboBox = new ObservableCollection<ComboBoxInfo>(cbi);
+                BodyIndex = 0;
 
-            if (cbi.Count <= 1)
+                if (cbi.Count <= 1)
+                {
+                    BodyEnabled = false;
+                }
+                else
+                {
+                    BodyEnabled = true;
+                }
+            } catch (Exception e)
             {
-                BodyEnabled = false;
-            }
-            else
-            {
-                BodyEnabled = true;
+                ResetBadCompositeState();
             }
         }
 
@@ -635,163 +642,169 @@ namespace FFXIV_TexTools2.ViewModel
         /// </summary>
         private void BodyComboBoxChanged()
         {
-            is3DLoaded = false;
-            bool isDemiHuman = false;
-
-            if (CompositeVM != null && !disposing)
+            try
             {
-                disposing = true;
-                CompositeVM.Dispose();
-            }
+                is3DLoaded = false;
+                bool isDemiHuman = false;
 
-            if (selectedItem.PrimaryMTRLFolder != null && selectedItem.PrimaryMTRLFolder.Contains("demihuman"))
-            {
-                isDemiHuman = true;
-            }
-
-            List<ComboBoxInfo> cbi = new List<ComboBoxInfo>();
-            string type = Helper.GetCategoryType(selectedCategory);
-
-            string MDLFolder = "";
-            string MDLFile = "";
-            string[] abrParts = null;
-
-            if (type.Equals("character"))
-            {
-                if (selectedItem.ItemName.Equals(Strings.Body))
+                if (CompositeVM != null && !disposing)
                 {
-                    MDLFolder = string.Format(Strings.BodyMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
-                    MDLFile = string.Format(Strings.BodyMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
+                    disposing = true;
+                    CompositeVM.Dispose();
+                }
+
+                if (selectedItem.PrimaryMTRLFolder != null && selectedItem.PrimaryMTRLFolder.Contains("demihuman"))
+                {
+                    isDemiHuman = true;
+                }
+
+                List<ComboBoxInfo> cbi = new List<ComboBoxInfo>();
+                string type = Helper.GetCategoryType(selectedCategory);
+
+                string MDLFolder = "";
+                string MDLFile = "";
+                string[] abrParts = null;
+
+                if (type.Equals("character"))
+                {
+                    if (selectedItem.ItemName.Equals(Strings.Body))
+                    {
+                        MDLFolder = string.Format(Strings.BodyMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
+                        MDLFile = string.Format(Strings.BodyMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
+
+                        abrParts = new string[5] { "met", "glv", "dwn", "sho", "top" };
+                    }
+                    else if (selectedItem.ItemName.Equals(Strings.Face))
+                    {
+                        MDLFolder = string.Format(Strings.FaceMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
+                        MDLFile = string.Format(Strings.FaceMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
+
+                        abrParts = new string[3] { "fac", "iri", "etc" };
+                    }
+                    else if (selectedItem.ItemName.Equals(Strings.Hair))
+                    {
+                        MDLFolder = string.Format(Strings.HairMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
+                        MDLFile = string.Format(Strings.HairMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
+
+                        abrParts = new string[2] { "hir", "acc" };
+                    }
+                    else if (selectedItem.ItemName.Equals(Strings.Tail))
+                    {
+                        MDLFolder = string.Format(Strings.TailMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
+                        MDLFile = string.Format(Strings.TailMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
+
+                        abrParts = new string[1] { "til" };
+                    }
+
+                    var fileHashList = Helper.GetAllFilesInFolder(FFCRC.GetHash(MDLFolder), Strings.ItemsDat);
+
+                    foreach (string abrPart in abrParts)
+                    {
+                        var file = String.Format(MDLFile, abrPart);
+
+                        if (fileHashList.Contains(FFCRC.GetHash(file)))
+                        {
+                            if (selectedItem.ItemName.Equals(Strings.Body))
+                            {
+                                cbi.Add(new ComboBoxInfo() { Name = Info.slotAbr.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
+                            }
+                            else if (selectedItem.ItemName.Equals(Strings.Face))
+                            {
+                                cbi.Add(new ComboBoxInfo() { Name = Info.FaceTypes.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
+                            }
+                            else if (selectedItem.ItemName.Equals(Strings.Hair))
+                            {
+                                cbi.Add(new ComboBoxInfo() { Name = Info.HairTypes.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
+                            }
+                            else if (selectedItem.ItemName.Equals(Strings.Tail))
+                            {
+                                cbi.Add(new ComboBoxInfo() { Name = Strings.Tail, ID = abrPart, IsNum = false });
+                            }
+                        }
+                    }
+                }
+                else if (isDemiHuman)
+                {
+                    MDLFolder = string.Format(Strings.DemiMDLFolder, selectedItem.PrimaryModelID, selectedItem.PrimaryModelBody);
+                    MDLFile = string.Format(Strings.DemiMDLFile, selectedItem.PrimaryModelID, selectedItem.PrimaryModelBody, "{0}");
 
                     abrParts = new string[5] { "met", "glv", "dwn", "sho", "top" };
-                }
-                else if (selectedItem.ItemName.Equals(Strings.Face))
-                {
-                    MDLFolder = string.Format(Strings.FaceMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
-                    MDLFile = string.Format(Strings.FaceMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
 
-                    abrParts = new string[3] { "fac", "iri", "etc" };
-                }
-                else if (selectedItem.ItemName.Equals(Strings.Hair))
-                {
-                    MDLFolder = string.Format(Strings.HairMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
-                    MDLFile = string.Format(Strings.HairMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
+                    var fileHashList = Helper.GetAllFilesInFolder(FFCRC.GetHash(MDLFolder), Strings.ItemsDat);
 
-                    abrParts = new string[2] { "hir", "acc" };
-                }
-                else if (selectedItem.ItemName.Equals(Strings.Tail))
-                {
-                    MDLFolder = string.Format(Strings.TailMDLFolder, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'));
-                    MDLFile = string.Format(Strings.TailMDLFile, SelectedRace.ID, SelectedBody.ID.PadLeft(4, '0'), "{0}");
-
-                    abrParts = new string[1] { "til" };
-                }
-
-                var fileHashList = Helper.GetAllFilesInFolder(FFCRC.GetHash(MDLFolder), Strings.ItemsDat);
-
-                foreach (string abrPart in abrParts)
-                {
-                    var file = String.Format(MDLFile, abrPart);
-
-                    if (fileHashList.Contains(FFCRC.GetHash(file)))
+                    foreach (string abrPart in abrParts)
                     {
-                        if (selectedItem.ItemName.Equals(Strings.Body))
+                        var file = String.Format(MDLFile, abrPart);
+
+                        if (fileHashList.Contains(FFCRC.GetHash(file)))
                         {
                             cbi.Add(new ComboBoxInfo() { Name = Info.slotAbr.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
                         }
-                        else if (selectedItem.ItemName.Equals(Strings.Face))
-                        {
-                            cbi.Add(new ComboBoxInfo() { Name = Info.FaceTypes.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
-                        }
-                        else if (selectedItem.ItemName.Equals(Strings.Hair))
-                        {
-                            cbi.Add(new ComboBoxInfo() { Name = Info.HairTypes.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
-                        }
-                        else if (selectedItem.ItemName.Equals(Strings.Tail))
-                        {
-                            cbi.Add(new ComboBoxInfo() { Name = Strings.Tail, ID = abrPart, IsNum = false });
-                        }
                     }
                 }
-            }
-            else if(isDemiHuman)
-            {
-                MDLFolder = string.Format(Strings.DemiMDLFolder, selectedItem.PrimaryModelID, selectedItem.PrimaryModelBody);
-                MDLFile = string.Format(Strings.DemiMDLFile, selectedItem.PrimaryModelID, selectedItem.PrimaryModelBody, "{0}");
-
-                abrParts = new string[5] { "met", "glv", "dwn", "sho", "top" };
-
-                var fileHashList = Helper.GetAllFilesInFolder(FFCRC.GetHash(MDLFolder), Strings.ItemsDat);
-
-                foreach (string abrPart in abrParts)
+                else if (type.Equals("weapon"))
                 {
-                    var file = String.Format(MDLFile, abrPart);
-
-                    if (fileHashList.Contains(FFCRC.GetHash(file)))
+                    if (selectedItem.SecondaryModelID != null)
                     {
-                        cbi.Add(new ComboBoxInfo() { Name = Info.slotAbr.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
+                        cbi.Add(new ComboBoxInfo() { Name = "Primary", ID = "Primary", IsNum = false });
+                        cbi.Add(new ComboBoxInfo() { Name = "Secondary", ID = "Secondary", IsNum = false });
+
+                    }
+                    else
+                    {
+                        cbi.Add(new ComboBoxInfo() { Name = "Primary", ID = "Primary", IsNum = false });
+
                     }
                 }
-            }
-            else if (type.Equals("weapon"))
-            {
-                if(selectedItem.SecondaryModelID != null)
+                else if (type.Equals("monster"))
                 {
-                    cbi.Add(new ComboBoxInfo() { Name = "Primary", ID = "Primary", IsNum = false });
-                    cbi.Add(new ComboBoxInfo() { Name = "Secondary", ID = "Secondary", IsNum = false });
+                    if (selectedCategory.Equals(Strings.Pets))
+                    {
+                        cbi.AddRange(MTRL.GetMTRLParts(selectedItem, SelectedRace.ID, "", selectedCategory));
+                    }
+                    else
+                    {
+                        cbi.Add(new ComboBoxInfo() { Name = "1", ID = "1", IsNum = false });
+                    }
+                }
+                else if (selectedItem.PrimaryModelID.Equals("9900"))
+                {
+                    MDLFolder = string.Format(Strings.EquipMDLFolder, selectedItem.PrimaryModelID);
+                    MDLFile = string.Format(Strings.EquipMDLFile, SelectedRace.ID, selectedItem.PrimaryModelID, "{0}");
 
+                    abrParts = new string[5] { "met", "glv", "dwn", "sho", "top" };
+
+                    var fileHashList = Helper.GetAllFilesInFolder(FFCRC.GetHash(MDLFolder), Strings.ItemsDat);
+
+                    foreach (string abrPart in abrParts)
+                    {
+                        var file = String.Format(MDLFile, abrPart);
+
+                        if (fileHashList.Contains(FFCRC.GetHash(file)))
+                        {
+                            cbi.Add(new ComboBoxInfo() { Name = Info.slotAbr.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
+                        }
+                    }
                 }
                 else
                 {
-                    cbi.Add(new ComboBoxInfo() { Name = "Primary", ID = "Primary", IsNum = false });
-
+                    cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });
                 }
-            }
-            else if(type.Equals("monster"))
-            {
-                if (selectedCategory.Equals(Strings.Pets))
+
+                PartComboBox = new ObservableCollection<ComboBoxInfo>(cbi);
+                PartIndex = 0;
+
+                if (cbi.Count <= 1)
                 {
-                    cbi.AddRange(MTRL.GetMTRLParts(selectedItem, SelectedRace.ID, "", selectedCategory));
+                    PartEnabled = false;
                 }
                 else
                 {
-                    cbi.Add(new ComboBoxInfo() { Name = "1", ID = "1", IsNum = false });
+                    PartEnabled = true;
                 }
-            }
-            else if (selectedItem.PrimaryModelID.Equals("9900"))
+            } catch (Exception e)
             {
-                MDLFolder = string.Format(Strings.EquipMDLFolder, selectedItem.PrimaryModelID);
-                MDLFile = string.Format(Strings.EquipMDLFile, SelectedRace.ID, selectedItem.PrimaryModelID, "{0}");
-
-                abrParts = new string[5] { "met", "glv", "dwn", "sho", "top" };
-
-                var fileHashList = Helper.GetAllFilesInFolder(FFCRC.GetHash(MDLFolder), Strings.ItemsDat);
-
-                foreach (string abrPart in abrParts)
-                {
-                    var file = String.Format(MDLFile, abrPart);
-
-                    if (fileHashList.Contains(FFCRC.GetHash(file)))
-                    {
-                        cbi.Add(new ComboBoxInfo() { Name = Info.slotAbr.FirstOrDefault(x => x.Value == abrPart).Key, ID = abrPart, IsNum = false });
-                    }
-                }
-            }
-            else
-            {
-                cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });
-            }
-
-            PartComboBox = new ObservableCollection<ComboBoxInfo>(cbi);
-            PartIndex = 0;
-
-            if (cbi.Count <= 1)
-            {
-                PartEnabled = false;
-            }
-            else
-            {
-                PartEnabled = true;
+                ResetBadCompositeState();
             }
         }
 
@@ -826,54 +839,61 @@ namespace FFXIV_TexTools2.ViewModel
         /// </summary>
         private void PartComboBoxChanged()
         {
-            is3DLoaded = false;
-
-            if (CompositeVM != null && !disposing)
-            {
-                disposing = true;
-                CompositeVM.Dispose();
-            }
-
-
-            List<ComboBoxInfo> cbi = new List<ComboBoxInfo>();
-
-            MDL mdl = new MDL(selectedItem, selectedCategory, Info.raceID[SelectedRace.Name], SelectedBody.ID, SelectedPart.ID);
-            meshList = mdl.GetMeshList();
-            modelName = mdl.GetModelName();
-            materialStrings = mdl.GetMaterialStrings();
-            fullPath = mdl.GetInternalPath();
-            modelData = mdl.GetModelData();
-
-            cbi.Add(new ComboBoxInfo() { Name = Strings.All, ID = Strings.All, IsNum = false });
-
-            if (meshList.Count > 1)
-            {
-                for (int i = 0; i < meshList.Count; i++)
-                {
-                    cbi.Add(new ComboBoxInfo() { Name = i.ToString(), ID = i.ToString(), IsNum = true });
-                }
-            }
-
-            MeshComboBox = new ObservableCollection<ComboBoxInfo>(cbi);
-            MeshIndex = 0;
-
-            if (cbi.Count > 1)
-            {
-                MeshEnabled = true;
-            }
-            else
-            {
-                MeshEnabled = false;
-            }
-
             try
             {
+                is3DLoaded = false;
 
-            }
-            catch (Exception ex)
+                if (CompositeVM != null && !disposing)
+                {
+                    disposing = true;
+                    CompositeVM.Dispose();
+                }
+
+
+                List<ComboBoxInfo> cbi = new List<ComboBoxInfo>();
+
+                MDL mdl = new MDL(selectedItem, selectedCategory, Info.raceID[SelectedRace.Name], SelectedBody.ID, SelectedPart.ID);
+                meshList = mdl.GetMeshList();
+                modelName = mdl.GetModelName();
+                materialStrings = mdl.GetMaterialStrings();
+                fullPath = mdl.GetInternalPath();
+                modelData = mdl.GetModelData();
+
+                cbi.Add(new ComboBoxInfo() { Name = Strings.All, ID = Strings.All, IsNum = false });
+
+                if (meshList.Count > 1)
+                {
+                    for (int i = 0; i < meshList.Count; i++)
+                    {
+                        cbi.Add(new ComboBoxInfo() { Name = i.ToString(), ID = i.ToString(), IsNum = true });
+                    }
+                }
+
+                MeshComboBox = new ObservableCollection<ComboBoxInfo>(cbi);
+                MeshIndex = 0;
+
+                if (cbi.Count > 1)
+                {
+                    MeshEnabled = true;
+                }
+                else
+                {
+                    MeshEnabled = false;
+                }
+
+                try
+                {
+
+                }
+                catch (Exception ex)
+                {
+                    FlexibleMessageBox.Show("part 3D Error \n" + ex.Message, "ModelViewModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    Debug.WriteLine(ex.StackTrace);
+                    ResetBadCompositeState();
+                }
+            } catch(Exception e)
             {
-                FlexibleMessageBox.Show("part 3D Error \n" + ex.Message, "ModelViewModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                Debug.WriteLine(ex.StackTrace);
+                ResetBadCompositeState();
             }
         }
 
@@ -908,106 +928,43 @@ namespace FFXIV_TexTools2.ViewModel
         /// </summary>
         private void MeshComboBoxChanged()
         {
-            if (!is3DLoaded)
+            try
             {
-                disposing = false;
-
-                meshData = new List<MDLTEXData>();
-
-                for (int i = 0; i < meshList.Count; i++)
+                if (!is3DLoaded)
                 {
-                    BitmapSource specularBMP = null;
-                    BitmapSource diffuseBMP = null;
-                    BitmapSource normalBMP = null;
-                    BitmapSource alphaBMP = null;
-                    BitmapSource maskBMP = null;
-                    BitmapSource emissiveBMP = null;
+                    disposing = false;
 
-                    TEXData specularData = null;
-                    TEXData diffuseData = null;
-                    TEXData normalData = null;
-                    TEXData maskData = null;
+                    meshData = new List<MDLTEXData>();
 
-                    bool isBody = false;
-                    bool isFace = false;
-
-                    MTRLData mtrlData = MTRL3D(i);
-
-                    if (selectedCategory.Equals(Strings.Character))
+                    for (int i = 0; i < meshList.Count; i++)
                     {
-                        if (selectedItem.ItemName.Equals(Strings.Tail) || selectedItem.ItemName.Equals(Strings.Hair))
+                        BitmapSource specularBMP = null;
+                        BitmapSource diffuseBMP = null;
+                        BitmapSource normalBMP = null;
+                        BitmapSource alphaBMP = null;
+                        BitmapSource maskBMP = null;
+                        BitmapSource emissiveBMP = null;
+
+                        TEXData specularData = null;
+                        TEXData diffuseData = null;
+                        TEXData normalData = null;
+                        TEXData maskData = null;
+
+                        bool isBody = false;
+                        bool isFace = false;
+
+                        MTRLData mtrlData = MTRL3D(i);
+
+                        if (selectedCategory.Equals(Strings.Character))
                         {
-                            if(mtrlData.MaskPath != null)
+                            if (selectedItem.ItemName.Equals(Strings.Tail) || selectedItem.ItemName.Equals(Strings.Hair))
                             {
-                                normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
-                                maskData = TEX.GetTex(mtrlData.MaskOffset, Strings.ItemsDat);
-
-                                var maps = TexHelper.MakeModelTextureMaps(normalData, null, maskData, null, mtrlData);
-
-                                diffuseBMP = maps[0];
-                                specularBMP = maps[1];
-                                normalBMP = maps[2];
-                                alphaBMP = maps[3];
-                                emissiveBMP = maps[4];
-                            }
-                            else
-                            {
-                                normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
-                                specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
-
-                                if (mtrlData.DiffusePath != null)
+                                if (mtrlData.MaskPath != null)
                                 {
-                                    diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
-                                }
+                                    normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
+                                    maskData = TEX.GetTex(mtrlData.MaskOffset, Strings.ItemsDat);
 
-                                var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
-
-                                diffuseBMP = maps[0];
-                                specularBMP = maps[1];
-                                normalBMP = maps[2];
-                                alphaBMP = maps[3];
-                            }
-                        }
-
-                        if (selectedItem.ItemName.Equals(Strings.Body))
-                        {
-                            normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
-                            specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
-                            diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
-
-                            isBody = true;
-
-                            var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
-
-                            diffuseBMP = maps[0];
-                            specularBMP = maps[1];
-                            normalBMP = maps[2];
-                            alphaBMP = maps[3];
-                        }
-
-                        if (selectedItem.ItemName.Equals(Strings.Face))
-                        {
-                            normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
-
-                            if (materialStrings[i].Contains("_fac_"))
-                            {
-                                specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
-                                diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
-
-                                var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
-
-                                diffuseBMP = maps[0];
-                                specularBMP = maps[1];
-                                normalBMP = maps[2];
-                                alphaBMP = maps[3];
-                                isFace = true;
-                            }
-                            else
-                            {
-                                if (mtrlData.ColorData != null)
-                                {
-                                    specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
-                                    var maps = TexHelper.MakeModelTextureMaps(normalData, null, null, specularData, mtrlData);
+                                    var maps = TexHelper.MakeModelTextureMaps(normalData, null, maskData, null, mtrlData);
 
                                     diffuseBMP = maps[0];
                                     specularBMP = maps[1];
@@ -1017,7 +974,14 @@ namespace FFXIV_TexTools2.ViewModel
                                 }
                                 else
                                 {
+                                    normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
                                     specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+
+                                    if (mtrlData.DiffusePath != null)
+                                    {
+                                        diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
+                                    }
+
                                     var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
 
                                     diffuseBMP = maps[0];
@@ -1026,28 +990,13 @@ namespace FFXIV_TexTools2.ViewModel
                                     alphaBMP = maps[3];
                                 }
                             }
-                        }
-                    }
-                    else
-                    {
 
-                        if (mtrlData.NormalOffset != 0)
-                        {
-                            normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
-                        }
-
-                        //if (mtrlData.MaskOffset != 0)
-                        //{
-                        //    maskData = TEX.GetTex(mtrlData.MaskOffset, Strings.ItemsDat);
-                        //    maskBMP = Imaging.CreateBitmapSourceFromHBitmap(maskData.BMP.GetHbitmap(), IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
-                        //}
-
-                        if (mtrlData.DiffuseOffset != 0)
-                        {
-                            diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
-                            specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
-                            if (mtrlData.DiffusePath.Contains("human") && !mtrlData.DiffusePath.Contains("demi"))
+                            if (selectedItem.ItemName.Equals(Strings.Body))
                             {
+                                normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
+                                specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+                                diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
+
                                 isBody = true;
 
                                 var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
@@ -1057,156 +1006,233 @@ namespace FFXIV_TexTools2.ViewModel
                                 normalBMP = maps[2];
                                 alphaBMP = maps[3];
                             }
-                        }
 
-                        if (!isBody && mtrlData.SpecularOffset != 0)
-                        {
-                            specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
-
-                            specularBMP = specularData.BMPSouceAlpha;
-                        }
-
-                        if (!isBody && specularData == null)
-                        {
-                            var maps = TexHelper.MakeModelTextureMaps(normalData, diffuseData, maskData, null, mtrlData);
-                            diffuseBMP = maps[0];
-                            specularBMP = maps[1];
-                            normalBMP = maps[2];
-                            alphaBMP = maps[3];
-                            emissiveBMP = maps[4];
-                        }
-                        else if (!isBody && specularData != null)
-                        {
-                            var maps = TexHelper.MakeModelTextureMaps(normalData, diffuseData, null, specularData, mtrlData);
-                            diffuseBMP = maps[0];
-                            specularBMP = maps[1];
-                            normalBMP = maps[2];
-                            alphaBMP = maps[3];
-                            emissiveBMP = maps[4];
-                        }
-                    }
-
-                    specularBMP?.Freeze();
-                    diffuseBMP?.Freeze();
-                    normalBMP?.Freeze();
-                    alphaBMP?.Freeze();
-                    emissiveBMP?.Freeze();
-
-                    var mData = new MDLTEXData()
-                    {
-                        Specular = specularBMP,
-                        Diffuse = diffuseBMP,
-                        Normal = normalBMP,
-                        Alpha = alphaBMP,
-                        Emissive = emissiveBMP,
-
-                        IsBody = isBody,
-                        IsFace = isFace,
-
-                        Mesh = meshList[i]
-                    };
-
-                    meshData.Add(mData);
-                }
-
-                
-                // Preserve Camera settings before reset
-                var lookDir = CompositeVM.Camera.LookDirection;
-                var upDir = CompositeVM.Camera.UpDirection;
-                var pos = CompositeVM.Camera.Position;
-
-
-                // Reset 3d View for loading new model
-                CompositeVM = new Composite3DViewModel();
-                CompositeVM.UpdateModel(meshData, selectedItem);
-
-                // Re-apply original camera settings 
-                // Applies when camera is not in the default position 
-                // and when within the same item category
-                if (lookDir.Z != -5 && !newCat)
-                {
-                    CompositeVM.Camera.LookDirection = lookDir;
-                    CompositeVM.Camera.UpDirection = upDir;
-                    CompositeVM.Camera.Position = pos;
-                }
-
-                is3DLoaded = true;
-                newCat = false;
-
-                if (File.Exists(Properties.Settings.Default.Save_Directory + "/" + selectedCategory + "/" + selectedItem.ItemName + "/3D/" + modelName + ".DAE"))
-                {
-                    Import3DEnabled = true;
-                    AdvImport3DEnabled = true;
-                }
-                else
-                {
-                    Import3DEnabled = false;
-                    AdvImport3DEnabled = false;
-                }
-
-                if (Directory.Exists(Properties.Settings.Default.Save_Directory + "/" + selectedCategory + "/" + selectedItem.ItemName + "/3D/"))
-                {
-                    Open3DEnabled = true;
-                }
-                else
-                {
-                    openEnabled = false;
-                }
-
-                string line;
-                JsonEntry modEntry = null;
-                bool inModList = false;
-                try
-                {
-                    using (StreamReader sr = new StreamReader(Properties.Settings.Default.Modlist_Directory))
-                    {
-                        while ((line = sr.ReadLine()) != null)
-                        {
-                            modEntry = JsonConvert.DeserializeObject<JsonEntry>(line);
-                            if (modEntry.fullPath.Equals(fullPath))
+                            if (selectedItem.ItemName.Equals(Strings.Face))
                             {
-                                inModList = true;
-                                break;
+                                normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
+
+                                if (materialStrings[i].Contains("_fac_"))
+                                {
+                                    specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+                                    diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
+
+                                    var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
+
+                                    diffuseBMP = maps[0];
+                                    specularBMP = maps[1];
+                                    normalBMP = maps[2];
+                                    alphaBMP = maps[3];
+                                    isFace = true;
+                                }
+                                else
+                                {
+                                    if (mtrlData.ColorData != null)
+                                    {
+                                        specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+                                        var maps = TexHelper.MakeModelTextureMaps(normalData, null, null, specularData, mtrlData);
+
+                                        diffuseBMP = maps[0];
+                                        specularBMP = maps[1];
+                                        normalBMP = maps[2];
+                                        alphaBMP = maps[3];
+                                        emissiveBMP = maps[4];
+                                    }
+                                    else
+                                    {
+                                        specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+                                        var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
+
+                                        diffuseBMP = maps[0];
+                                        specularBMP = maps[1];
+                                        normalBMP = maps[2];
+                                        alphaBMP = maps[3];
+                                    }
+                                }
                             }
                         }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    FlexibleMessageBox.Show("Error Accessing .modlist File \n" + ex.Message, "ModelViewModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Error);
-                }
+                        else
+                        {
 
-                if (inModList)
-                {
-                    var currOffset = Helper.GetDataOffset(FFCRC.GetHash(modEntry.fullPath.Substring(0, modEntry.fullPath.LastIndexOf("/"))), FFCRC.GetHash(Path.GetFileName(modEntry.fullPath)), Strings.ItemsDat);
+                            if (mtrlData.NormalOffset != 0)
+                            {
+                                normalData = TEX.GetTex(mtrlData.NormalOffset, Strings.ItemsDat);
+                            }
 
-                    if (currOffset == modEntry.modOffset)
-                    {
-                        ActiveToggle = "Disable";
+                            //if (mtrlData.MaskOffset != 0)
+                            //{
+                            //    maskData = TEX.GetTex(mtrlData.MaskOffset, Strings.ItemsDat);
+                            //    maskBMP = Imaging.CreateBitmapSourceFromHBitmap(maskData.BMP.GetHbitmap(), IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromEmptyOptions());
+                            //}
+
+                            if (mtrlData.DiffuseOffset != 0)
+                            {
+                                diffuseData = TEX.GetTex(mtrlData.DiffuseOffset, Strings.ItemsDat);
+                                specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+                                if (mtrlData.DiffusePath.Contains("human") && !mtrlData.DiffusePath.Contains("demi"))
+                                {
+                                    isBody = true;
+
+                                    var maps = TexHelper.MakeCharacterMaps(normalData, diffuseData, null, specularData, selectedItem.ItemName, mtrlData.MTRLPath);
+
+                                    diffuseBMP = maps[0];
+                                    specularBMP = maps[1];
+                                    normalBMP = maps[2];
+                                    alphaBMP = maps[3];
+                                }
+                            }
+
+                            if (!isBody && mtrlData.SpecularOffset != 0)
+                            {
+                                specularData = TEX.GetTex(mtrlData.SpecularOffset, Strings.ItemsDat);
+
+                                specularBMP = specularData.BMPSouceAlpha;
+                            }
+
+                            if (!isBody && specularData == null)
+                            {
+                                var maps = TexHelper.MakeModelTextureMaps(normalData, diffuseData, maskData, null, mtrlData);
+                                diffuseBMP = maps[0];
+                                specularBMP = maps[1];
+                                normalBMP = maps[2];
+                                alphaBMP = maps[3];
+                                emissiveBMP = maps[4];
+                            }
+                            else if (!isBody && specularData != null)
+                            {
+                                var maps = TexHelper.MakeModelTextureMaps(normalData, diffuseData, null, specularData, mtrlData);
+                                diffuseBMP = maps[0];
+                                specularBMP = maps[1];
+                                normalBMP = maps[2];
+                                alphaBMP = maps[3];
+                                emissiveBMP = maps[4];
+                            }
+                        }
+
+                        specularBMP?.Freeze();
+                        diffuseBMP?.Freeze();
+                        normalBMP?.Freeze();
+                        alphaBMP?.Freeze();
+                        emissiveBMP?.Freeze();
+
+                        var mData = new MDLTEXData()
+                        {
+                            Specular = specularBMP,
+                            Diffuse = diffuseBMP,
+                            Normal = normalBMP,
+                            Alpha = alphaBMP,
+                            Emissive = emissiveBMP,
+
+                            IsBody = isBody,
+                            IsFace = isFace,
+
+                            Mesh = meshList[i]
+                        };
+
+                        meshData.Add(mData);
                     }
-                    else if (currOffset == modEntry.originalOffset)
+
+
+                    // Preserve Camera settings before reset
+                    var lookDir = CompositeVM.Camera.LookDirection;
+                    var upDir = CompositeVM.Camera.UpDirection;
+                    var pos = CompositeVM.Camera.Position;
+
+
+                    // Reset 3d View for loading new model
+                    CompositeVM = new Composite3DViewModel();
+                    CompositeVM.UpdateModel(meshData, selectedItem);
+
+                    // Re-apply original camera settings 
+                    // Applies when camera is not in the default position 
+                    // and when within the same item category
+                    if (lookDir.Z != -5 && !newCat)
                     {
-                        ActiveToggle = "Enable";
+                        CompositeVM.Camera.LookDirection = lookDir;
+                        CompositeVM.Camera.UpDirection = upDir;
+                        CompositeVM.Camera.Position = pos;
+                    }
+
+                    is3DLoaded = true;
+                    newCat = false;
+
+                    if (File.Exists(Properties.Settings.Default.Save_Directory + "/" + selectedCategory + "/" + selectedItem.ItemName + "/3D/" + modelName + ".DAE"))
+                    {
+                        Import3DEnabled = true;
+                        AdvImport3DEnabled = true;
                     }
                     else
                     {
-                        ActiveToggle = "Error";
+                        Import3DEnabled = false;
+                        AdvImport3DEnabled = false;
                     }
 
-                    ActiveEnabled = true;
+                    if (Directory.Exists(Properties.Settings.Default.Save_Directory + "/" + selectedCategory + "/" + selectedItem.ItemName + "/3D/"))
+                    {
+                        Open3DEnabled = true;
+                    }
+                    else
+                    {
+                        openEnabled = false;
+                    }
+
+                    string line;
+                    JsonEntry modEntry = null;
+                    bool inModList = false;
+                    try
+                    {
+                        using (StreamReader sr = new StreamReader(Properties.Settings.Default.Modlist_Directory))
+                        {
+                            while ((line = sr.ReadLine()) != null)
+                            {
+                                modEntry = JsonConvert.DeserializeObject<JsonEntry>(line);
+                                if (modEntry.fullPath.Equals(fullPath))
+                                {
+                                    inModList = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        FlexibleMessageBox.Show("Error Accessing .modlist File \n" + ex.Message, "ModelViewModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+
+                    if (inModList)
+                    {
+                        var currOffset = Helper.GetDataOffset(FFCRC.GetHash(modEntry.fullPath.Substring(0, modEntry.fullPath.LastIndexOf("/"))), FFCRC.GetHash(Path.GetFileName(modEntry.fullPath)), Strings.ItemsDat);
+
+                        if (currOffset == modEntry.modOffset)
+                        {
+                            ActiveToggle = "Disable";
+                        }
+                        else if (currOffset == modEntry.originalOffset)
+                        {
+                            ActiveToggle = "Enable";
+                        }
+                        else
+                        {
+                            ActiveToggle = "Error";
+                        }
+
+                        ActiveEnabled = true;
+                    }
+                    else
+                    {
+                        ActiveEnabled = false;
+                        ActiveToggle = "Enable/Disable";
+                    }
+
+                    ReflectionContent = "Reflection " + string.Format("{0:0.##}", CompositeVM.CurrentSS);
+
                 }
                 else
                 {
-                    ActiveEnabled = false;
-                    ActiveToggle = "Enable/Disable";
+                    CompositeVM.Rendering(SelectedMesh.Name);
                 }
-
-                ReflectionContent = "Reflection " + string.Format("{0:0.##}", CompositeVM.CurrentSS);
-
-            }
-            else
+            } catch(Exception e)
             {
-                CompositeVM.Rendering(SelectedMesh.Name);
+                ResetBadCompositeState();
             }
         }
 
@@ -1381,6 +1407,17 @@ namespace FFXIV_TexTools2.ViewModel
         {
             if (this.PropertyChanged != null)
                 PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        protected void ResetBadCompositeState()
+        {
+            if(CompositeVM != null && !CompositeVM.IsDead())
+            {
+                CompositeVM.Dispose();
+            }
+
+            CompositeVM = new Composite3DViewModel();
+            FlexibleMessageBox.Show("The 3D Model Viewer was unable to display the item.", "Model Viewer Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
     }
 }

--- a/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
@@ -108,6 +108,10 @@ namespace FFXIV_TexTools2.ViewModel
         {
             selectedItem = item;
             selectedCategory = category;
+            if(selectedItem == null || selectedCategory == null)
+            {
+                return;
+            }
 
             if (!category.Equals("UI"))
             {

--- a/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
@@ -136,6 +136,11 @@ namespace FFXIV_TexTools2.ViewModel
             RaceIndex = 0;
         }
 
+        public void ReloadTexture()
+        {
+            UpdateTexture(selectedItem, selectedCategory);
+        }
+
         public TextureViewModel()
         {
 

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.7&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8 Beta&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.7 Beta&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.7&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8 Beta&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/AdvImport.xaml
+++ b/FFXIV_TexTools2/Views/AdvImport.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:FFXIV_TexTools2.Views"
         mc:Ignorable="d"
-        Title="3D Import Options" Width="655" WindowStyle="ToolWindow" WindowStartupLocation="CenterOwner" Height="728" ResizeMode="NoResize">
+        Title="3D Import Options" Width="655" WindowStyle="ToolWindow" WindowStartupLocation="CenterOwner" Height="743" ResizeMode="NoResize">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -61,10 +61,10 @@
                 <Label Content="Bones:" HorizontalAlignment="Left" Margin="411,12,0,0" VerticalAlignment="Top" Width="86"/>
                 <Label Content="Bone addition is automatic" HorizontalAlignment="Left" Margin="432,147,0,0" VerticalAlignment="Top"/>
             </Grid>
-            <Grid x:Name="MeshStatusGrid" Margin="0,204,12,-62" Grid.Row="1" Panel.ZIndex="10" HorizontalAlignment="Right" Width="627" Height="407" VerticalAlignment="Top">
+            <Grid x:Name="MeshStatusGrid" Margin="0,204,12,-78" Grid.Row="1" Panel.ZIndex="10" HorizontalAlignment="Right" Width="627" Height="423" VerticalAlignment="Top">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="184*"/>
-                    <RowDefinition Height="221*"/>
+                    <RowDefinition Height="237*"/>
                     <RowDefinition Height="2*"/>
                 </Grid.RowDefinitions>
                 <Grid.ColumnDefinitions>
@@ -80,8 +80,8 @@
                 <Button x:Name="CancelButton" Content="Cancel" Margin="0,0,67,7" Click="CancelButton_Click" Grid.Row="1" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="41" />
                 <Button x:Name="ImportButton" Content="Import" Margin="0,0,10,7" Click="ImportButton_Click" Grid.Row="1" Height="30" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="42" />
                 <Label Content="*Note: These options are still in development and may not work properly." Margin="0,0,0,8" Grid.Row="1" HorizontalAlignment="Left" Width="398" Height="26" VerticalAlignment="Bottom" />
-                <CheckBox x:Name="FixCheckbox" Grid.Row="0" Content="Attempt Fix" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="493,40,0,118" Checked="FixCheckbox_Checked" Unchecked="FixCheckbox_Unchecked" Height="26" Width="124" IsEnabled="False"/>
-                <CheckBox x:Name="DisableCheckbox" Content="Disable Extra Data" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="493,66,0,92" Checked="DisableCheckbox_Checked" Unchecked="DisableCheckbox_Unchecked" Height="26" Width="124" IsEnabled="False"/>
+                <CheckBox x:Name="FixCheckbox" Grid.Row="0" Content="Attempt Fix" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="493,39,0,119" Checked="FixCheckbox_Checked" Unchecked="FixCheckbox_Unchecked" Height="26" Width="124" IsEnabled="False"/>
+                <CheckBox x:Name="DisableCheckbox" Content="Disable Extra Data" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="493,65,0,93" Checked="DisableCheckbox_Checked" Unchecked="DisableCheckbox_Unchecked" Height="26" Width="124" IsEnabled="False"/>
                 <Label x:Name="ExtraMeshDataLabel" Content="Extra Mesh Data:" HorizontalAlignment="Left" Margin="472,10,0,0" VerticalAlignment="Top" Height="26" Width="99"/>
                 <Border BorderBrush="Black" BorderThickness="1" HorizontalAlignment="Left" Height="80" Margin="465,10,0,0" VerticalAlignment="Top" Width="152"/>
                 <Border BorderBrush="Black" BorderThickness="1" Grid.RowSpan="2" Panel.ZIndex="-10" Margin="0,0,0,47">
@@ -97,6 +97,7 @@
             </Grid>
         </Grid>
         <Border BorderBrush="Black" BorderThickness="1" Margin="10,415,12,0" Grid.Row="1" Height="1" VerticalAlignment="Top"/>
+        <CheckBox x:Name="UseOrignalBones" Content="Use Original Bones" HorizontalAlignment="Left" Margin="494,56,0,0" Grid.Row="1" VerticalAlignment="Top" Checked="UseOriginalBones_Checked" Unchecked="UseOriginalBones_Unchecked" />
 
 
     </Grid>

--- a/FFXIV_TexTools2/Views/AdvImport.xaml
+++ b/FFXIV_TexTools2/Views/AdvImport.xaml
@@ -21,7 +21,7 @@
                     <ColumnDefinition/>
                     <ColumnDefinition/>
                 </Grid.ColumnDefinitions>
-                <TextBox x:Name="ImportDir" Grid.Row="1" Grid.ColumnSpan="2" TextWrapping="Wrap" IsReadOnly="True" Margin="5,0,25,0"/>
+                <TextBox x:Name="ImportDir" Grid.Row="1" Grid.ColumnSpan="2" IsReadOnly="True" Margin="5,0,25,0"/>
                 <Label Grid.Row="0" Content="Importing File" VerticalAlignment="Top" Height="15" Padding="0" Margin="5,0,0,0"/>
                 <Button x:Name="AdvImportButton" Content="..." Grid.Column="1" Grid.Row="1" Width="20" Height="20" HorizontalAlignment="Right" Click="AdvImportButton_Click"/>
             </Grid>

--- a/FFXIV_TexTools2/Views/AdvImport.xaml.cs
+++ b/FFXIV_TexTools2/Views/AdvImport.xaml.cs
@@ -188,6 +188,18 @@ namespace FFXIV_TexTools2.Views
             CreateXMLButton.IsEnabled = false;
         }
 
+        private void UseOriginalBones_Checked(object sender, RoutedEventArgs e)
+        {
+            importDict[MeshComboBox.SelectedItem.ToString()].UseOriginalBones = true;
+
+        }
+
+        private void UseOriginalBones_Unchecked(object sender, RoutedEventArgs e)
+        {
+            importDict[MeshComboBox.SelectedItem.ToString()].UseOriginalBones = false;
+
+        }
+
         private void MakeXML()
         {
             XmlWriterSettings xmlWriterSettings = new XmlWriterSettings()
@@ -368,7 +380,16 @@ namespace FFXIV_TexTools2.Views
             MeshPart newPart = new MeshPart();
             modelData.LoD[0].MeshList[meshNum].MeshPartList.Add(newPart);
 
+            newPart = new MeshPart();
+            modelData.LoD[1].MeshList[meshNum].MeshPartList.Add(newPart);
+
+            newPart = new MeshPart();
+            modelData.LoD[2].MeshList[meshNum].MeshPartList.Add(newPart);
+
             MeshPartCount.Content = modelData.LoD[0].MeshList[meshNum].MeshPartList.Count;
+            MeshPartCount.Content = modelData.LoD[1].MeshList[meshNum].MeshPartList.Count;
+            MeshPartCount.Content = modelData.LoD[2].MeshList[meshNum].MeshPartList.Count;
+
             List<int> parts = (List<int>) PartComboBox.ItemsSource;
             parts.Add(modelData.LoD[0].MeshList[meshNum].MeshPartList.Count - 1);
             PartComboBox.ItemsSource = null;
@@ -541,17 +562,15 @@ namespace FFXIV_TexTools2.Views
 
         private void AddMeshButton_Click(object sender, RoutedEventArgs e)
         {
-            // Only need to actually add a new mesh to LoD 0
-            // Since LoD 1+ is dummy data.
-            //for (int l = 0; l < modelData.LoD.Count; l++)
-            //{
+            for (int l = 0; l < modelData.LoD.Count; l++)
+            {
                 var mesh = new Mesh();
                 var newPart = new MeshPart();
                 mesh.MeshPartList = new List<MeshPart>();
                 mesh.MeshPartList.Add(newPart);
-                modelData.LoD[0].MeshList.Add(mesh);
-                modelData.LoD[0].MeshCount += 1;
-           // }
+                modelData.LoD[l].MeshList.Add(mesh);
+                modelData.LoD[l].MeshCount += 1;
+            }
 
             importDict.Add((modelData.LoD[0].MeshCount - 1).ToString(), new ImportSettings());
 
@@ -580,6 +599,7 @@ namespace FFXIV_TexTools2.Views
 
             if (!MeshComboBox.SelectedItem.ToString().Equals(Strings.All))
             {
+                UseOrignalBones.IsEnabled = false;
                 selectedItem = int.Parse(MeshComboBox.SelectedItem.ToString());
 
 
@@ -603,9 +623,11 @@ namespace FFXIV_TexTools2.Views
                 selectedItem = -1;
                 DisableCheckbox.IsEnabled = true;
                 FixCheckbox.IsEnabled = true;
+                UseOrignalBones.IsEnabled = true;
             }
             else
             {
+                UseOrignalBones.IsEnabled = true;
                 selectedItem = -1;
             }
 

--- a/FFXIV_TexTools2/Views/AdvImport.xaml.cs
+++ b/FFXIV_TexTools2/Views/AdvImport.xaml.cs
@@ -572,6 +572,19 @@ namespace FFXIV_TexTools2.Views
                 modelData.LoD[l].MeshCount += 1;
             }
 
+            for (int l = 1; l < modelData.LoD.Count; l++)
+            {
+                while (modelData.LoD[l].MeshCount < modelData.LoD[0].MeshCount)
+                {
+                    var mesh = new Mesh();
+                    var newPart = new MeshPart();
+                    mesh.MeshPartList = new List<MeshPart>();
+                    mesh.MeshPartList.Add(newPart);
+                    modelData.LoD[l].MeshList.Add(mesh);
+                    modelData.LoD[l].MeshCount += 1;
+                }
+            }
+
             importDict.Add((modelData.LoD[0].MeshCount - 1).ToString(), new ImportSettings());
 
 

--- a/FFXIV_TexTools2/Views/Customize.xaml
+++ b/FFXIV_TexTools2/Views/Customize.xaml
@@ -5,15 +5,16 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:FFXIV_TexTools2.Views"
         mc:Ignorable="d"
-        Title="Customize" Height="300" Width="400" WindowStyle="ToolWindow" WindowStartupLocation="CenterOwner">
-    <Grid>
+        Title="Customize" Height="387.076" Width="400" WindowStyle="ToolWindow" WindowStartupLocation="CenterOwner">
+    <Grid Height="351" VerticalAlignment="Top">
         <Grid.RowDefinitions>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
+            <RowDefinition Height="46*"/>
+            <RowDefinition Height="46*"/>
+            <RowDefinition Height="46*"/>
+            <RowDefinition Height="46*"/>
+            <RowDefinition Height="46*"/>
+            <RowDefinition Height="46*"/>
+            <RowDefinition Height="46*"/>
         </Grid.RowDefinitions>
         <StackPanel Orientation="Horizontal">
             <Label Content="Default Race: " HorizontalAlignment="Left" VerticalAlignment="Center" />
@@ -21,7 +22,7 @@
             <Label Content="This only affects shared races" HorizontalAlignment="Left" VerticalAlignment="Center" />
 
         </StackPanel>
-        <StackPanel Grid.Row="1" Orientation="Horizontal">
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Height="46" VerticalAlignment="Top">
             <Label Content="Skin Color" HorizontalAlignment="Left" VerticalAlignment="Center" />
             <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0" />
             <TextBox x:Name="SkinR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="SkinR_TextChanged" />
@@ -31,7 +32,7 @@
             <TextBox x:Name="SkinB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="SkinB_TextChanged" />
             <Rectangle x:Name="SkinColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="20,0,0,0" Stroke="Black"/>
         </StackPanel>
-        <StackPanel Grid.Row="2" Orientation="Horizontal">
+        <StackPanel Grid.Row="2" Orientation="Horizontal" Height="46" VerticalAlignment="Top">
             <Label Content="Hair Color" HorizontalAlignment="Left" VerticalAlignment="Center" />
             <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0"  />
             <TextBox x:Name="HairR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="HairR_TextChanged" />
@@ -42,7 +43,7 @@
             <Rectangle x:Name="HairColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="20,0,0,0" Stroke="Black"/>
 
         </StackPanel>
-        <StackPanel Grid.Row="3" Orientation="Horizontal">
+        <StackPanel Grid.Row="3" Orientation="Horizontal" Height="46" VerticalAlignment="Top">
             <Label Content="Eye Color " HorizontalAlignment="Left" VerticalAlignment="Center" />
             <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0"  />
             <TextBox x:Name="EyeR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="EyeR_TextChanged" />
@@ -52,7 +53,7 @@
             <TextBox x:Name="EyeB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="EyeB_TextChanged" />
             <Rectangle x:Name="EyeColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="20,0,0,0" Stroke="Black"/>
         </StackPanel>
-        <StackPanel Grid.Row="4" Orientation="Horizontal">
+        <StackPanel Grid.Row="4" Orientation="Horizontal" Height="46" VerticalAlignment="Top">
             <Label Content="Etc. Color " HorizontalAlignment="Left" VerticalAlignment="Center" />
             <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0"  />
             <TextBox x:Name="EtcR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="EtcR_TextChanged" />
@@ -62,6 +63,14 @@
             <TextBox x:Name="EtcB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="EtcB_TextChanged" />
             <Rectangle x:Name="EtcColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="20,0,0,0" Stroke="Black"/>
         </StackPanel>
-        <Button x:Name="SetButton" Content="Set" HorizontalAlignment="Right" Grid.Row="5" Width="75" VerticalAlignment="Center" Margin="0,0,20,0" Click="SetButton_Click"/>
+        <Button x:Name="SetButton" Content="Set" HorizontalAlignment="Right" Grid.Row="6" Width="75" VerticalAlignment="Top" Margin="0,19,10,0" Click="SetButton_Click"/>
+        <Label Content="BG Color" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,7,0,17" Grid.Row="5" />
+        <TextBox x:Name="BGR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" Margin="90,9,272,19" Grid.Row="5" TextChanged="BGR_TextChanged" />
+        <TextBox x:Name="BGG" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGG_TextChanged" Margin="148,9,214,19" Grid.Row="5" />
+        <TextBox x:Name="BGB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGB_TextChanged" Margin="205,9,157,19" Grid.Row="5" />
+        <Rectangle x:Name="BGColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="255,10,0,20" Stroke="Black" Grid.Row="5"/>
+        <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="73,7,0,17" Grid.Row="5"  />
+        <Label Content="G" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="130,7,0,17" Grid.Row="5"  />
+        <Label Content="B" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="188,7,0,17" Grid.Row="5"  />
     </Grid>
 </Window>

--- a/FFXIV_TexTools2/Views/Customize.xaml
+++ b/FFXIV_TexTools2/Views/Customize.xaml
@@ -63,14 +63,16 @@
             <TextBox x:Name="EtcB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="EtcB_TextChanged" />
             <Rectangle x:Name="EtcColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="20,0,0,0" Stroke="Black"/>
         </StackPanel>
+        <StackPanel Grid.Row="5" Orientation="Horizontal" Height="46" VerticalAlignment="Top">
+            <Label Content="BG Color " HorizontalAlignment="Left" VerticalAlignment="Center" />
+            <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0"  />
+            <TextBox x:Name="BGR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGR_TextChanged" />
+            <Label Content="G" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0"  />
+            <TextBox x:Name="BGG" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGG_TextChanged" />
+            <Label Content="B" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10,0,0,0"  />
+            <TextBox x:Name="BGB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGB_TextChanged" />
+            <Rectangle x:Name="BGColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="20,0,0,0" Stroke="Black"/>
+        </StackPanel>
         <Button x:Name="SetButton" Content="Set" HorizontalAlignment="Right" Grid.Row="6" Width="75" VerticalAlignment="Top" Margin="0,19,10,0" Click="SetButton_Click"/>
-        <Label Content="BG Color" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0,7,0,17" Grid.Row="5" />
-        <TextBox x:Name="BGR" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" Margin="90,9,272,19" Grid.Row="5" TextChanged="BGR_TextChanged" />
-        <TextBox x:Name="BGG" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGG_TextChanged" Margin="148,9,214,19" Grid.Row="5" />
-        <TextBox x:Name="BGB" TextWrapping="Wrap" VerticalAlignment="Center" MinWidth="30" TextChanged="BGB_TextChanged" Margin="205,9,157,19" Grid.Row="5" />
-        <Rectangle x:Name="BGColor"  Width="20" Height="20" HorizontalAlignment="Left" Margin="255,10,0,20" Stroke="Black" Grid.Row="5"/>
-        <Label Content="R" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="73,7,0,17" Grid.Row="5"  />
-        <Label Content="G" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="130,7,0,17" Grid.Row="5"  />
-        <Label Content="B" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="188,7,0,17" Grid.Row="5"  />
     </Grid>
 </Window>

--- a/FFXIV_TexTools2/Views/Customize.xaml.cs
+++ b/FFXIV_TexTools2/Views/Customize.xaml.cs
@@ -22,7 +22,7 @@ namespace FFXIV_TexTools2.Views
     /// </summary>
     public partial class Customize : Window
     {
-        private Color skinColor, hairColor, eyeColor, etcColor;
+        private Color skinColor, hairColor, eyeColor, etcColor, bgColor;
 
         public Customize()
         {
@@ -40,6 +40,7 @@ namespace FFXIV_TexTools2.Views
             hairColor = (Color)ColorConverter.ConvertFromString(Properties.Settings.Default.Hair_Color);
             eyeColor = (Color)ColorConverter.ConvertFromString(Properties.Settings.Default.Iris_Color);
             etcColor = (Color)ColorConverter.ConvertFromString(Properties.Settings.Default.Etc_Color);
+            bgColor = (Color)ColorConverter.ConvertFromString(Properties.Settings.Default.BG_Color);
 
             RaceComboBox.ItemsSource = baseRace;
             RaceComboBox.SelectedIndex = baseRace.IndexOf(Properties.Settings.Default.Default_Race);
@@ -60,10 +61,15 @@ namespace FFXIV_TexTools2.Views
             EtcG.Text = etcColor.G.ToString();
             EtcB.Text = etcColor.B.ToString();
 
+            BGR.Text = bgColor.R.ToString();
+            BGG.Text = bgColor.G.ToString();
+            BGB.Text = bgColor.B.ToString();
+
             SkinColor.Fill = new SolidColorBrush(skinColor);
             HairColor.Fill = new SolidColorBrush(hairColor);
             EyeColor.Fill = new SolidColorBrush(eyeColor);
             EtcColor.Fill = new SolidColorBrush(etcColor);
+            BGColor.Fill = new SolidColorBrush(bgColor);
 
         }
 
@@ -279,6 +285,75 @@ namespace FFXIV_TexTools2.Views
             }
         }
 
+        private void BGR_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var s = sender as TextBox;
+
+            try
+            {
+                var num = int.Parse(s.Text);
+                if (num < 0 || num > 255)
+                {
+                    s.Text = "";
+                }
+                else
+                {
+                    bgColor = Color.FromArgb(255, (byte)num, bgColor.G, bgColor.B);
+                    BGColor.Fill = new SolidColorBrush(bgColor);
+                }
+            }
+            catch
+            {
+                s.Text = "";
+            }
+        }
+
+        private void BGG_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var s = sender as TextBox;
+
+            try
+            {
+                var num = int.Parse(s.Text);
+                if (num < 0 || num > 255)
+                {
+                    s.Text = "";
+                }
+                else
+                {
+                    bgColor = Color.FromArgb(255, bgColor.R, (byte)num, bgColor.B);
+                    BGColor.Fill = new SolidColorBrush(bgColor);
+                }
+            }
+            catch
+            {
+                s.Text = "";
+            }
+        }
+
+        private void BGB_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            var s = sender as TextBox;
+
+            try
+            {
+                var num = int.Parse(s.Text);
+                if (num < 0 || num > 255)
+                {
+                    s.Text = "";
+                }
+                else
+                {
+                    bgColor = Color.FromArgb(255, bgColor.R, bgColor.G, (byte)num);
+                    BGColor.Fill = new SolidColorBrush(bgColor);
+                }
+            }
+            catch
+            {
+                s.Text = "";
+            }
+        }
+
         private void EtcR_TextChanged(object sender, TextChangedEventArgs e)
         {
             var s = sender as TextBox;
@@ -355,6 +430,7 @@ namespace FFXIV_TexTools2.Views
             Properties.Settings.Default.Hair_Color = hairColor.ToString();
             Properties.Settings.Default.Iris_Color = eyeColor.ToString();
             Properties.Settings.Default.Etc_Color = etcColor.ToString();
+            Properties.Settings.Default.BG_Color = bgColor.ToString();
 
             Properties.Settings.Default.Save();
 

--- a/FFXIV_TexTools2/Views/ModList.xaml
+++ b/FFXIV_TexTools2/Views/ModList.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:src="clr-namespace:FFXIV_TexTools2.Model"
         mc:Ignorable="d"
-        Title="ModList" Height="500" Width="800" WindowStartupLocation="CenterOwner">
+        Title="ModList" Height="500" Width="800" WindowStartupLocation="CenterOwner" Closed="Window_Closed">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>

--- a/FFXIV_TexTools2/Views/ModList.xaml.cs
+++ b/FFXIV_TexTools2/Views/ModList.xaml.cs
@@ -32,9 +32,15 @@ namespace FFXIV_TexTools2.Views
     /// </summary>
     public partial class ModList : Window
     {
-        public ModList()
+        ModelViewModel mvm;
+        TextureViewModel tvm;
+
+        public ModList(ModelViewModel mvm, TextureViewModel tvm)
         {
             InitializeComponent();
+
+            this.mvm = mvm;
+            this.tvm = tvm;
 
             ModListViewModel vm = new ModListViewModel();
             modListTreeView.DataContext = vm;
@@ -172,6 +178,18 @@ namespace FFXIV_TexTools2.Views
             {
                 ModListViewModel vm = new ModListViewModel();
                 modListTreeView.DataContext = vm;
+            }
+        }
+
+        private void Window_Closed(object sender, EventArgs e)
+        {
+            if (tvm != null)
+            {
+                tvm.ReloadTexture();
+            }
+            if (mvm != null)
+            {
+                mvm.ReloadModel();
             }
         }
     }


### PR DESCRIPTION
Patch-notes are in the Readme.md, but also included here.

Application:
 - Guest update by Sel/Lunaretic [https://github.com/Lunaretic]
 - Added an option to change the model viewer background color.
 - Closing the Modlist menu now automatically refreshes the current model and textures.
 
Textures:
 - Icons with multiple stacks/versions are now editable.

3D:
 - All body technical assets under character-body are now editable (Don't play with them unless you know what you're doing; standard nude bodies are under Smallclothes)
- 3D Models now import with correct LoD Data.  (Does not apply to old .ttmps; they must be manually reimported & repackaged)
  - Higher LoD levels have extra mesh data automatically disabled for now.
- An option has been added to the Advanced Import menu to use the original Bones from an item.
  - This is an edge-case handling for items with more than 64 bones, and some animated items. (ex. Antecedent's Attire, Astro Globes)
  - Items using Original Bones cannot have Mesh Groups or Bones added to them.  Mesh Parts may be added, but can only use bones already in their mesh group.
  
Bug Fixes:
- Fixed importing DX9 Models (Does not apply to old .ttmps; they must be manually reimported & repackaged)
- Fixed issues with very large/complex models exceeding the header length limit and crashing with a Model 3 Data error.
- The 3D Model viewer now crashes more gracefully.

Known Issues:
 - Skeleton files may need updating for some newer items. (Ex. Some Hairstyles and Bonewicca pieces)