### PR TITLE
Modlist close Crash Fix

### DIFF
--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -98,6 +98,11 @@ namespace FFXIV_TexTools2.ViewModel
 
         public void UpdateModel(ItemData item, string category)
         {
+            if(item == null || category == null)
+            {
+                return;
+            }
+
             CompositeVM.Dispose();
             disposing = true;
             cbi.Clear();


### PR DESCRIPTION
Adds an additional guard clause to prevent a crash on closing modlist without any models open.

For some reason the crash doesn't happen to me on my development environment; I'm not sure if this is partially an issue with some of the dependencies being outdated in the packaged version released, but this is an extra guard clause to make sure there's no crash.

It's a non-critical error, so there's no particular need to actually update this, but I figure I'd send you the pull request anyways if you decide you want to add it in.