### PR TITLE
1.9.8.3 - Bugfixes

### DIFF
--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -2116,7 +2116,8 @@ namespace FFXIV_TexTools2.IO
                             }
                         } else
                         {
-                            if (importSettings[Strings.All].UseOriginalBones)
+                            // Don't allow mesh addition in LoD 0 with 'Use Original Bones'
+                            if (importSettings[Strings.All].UseOriginalBones && i == 0)
                             {
                                 MessageBox.Show("Mesh Addition is not allowed when using Original Bones.\n\nThe import has been canceled.");
                                 return;

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -2442,13 +2442,20 @@ namespace FFXIV_TexTools2.IO
                             //Attributes (int)
                             // If we're still in the original Mesh Part listing, advance the seek cursor.
                             int originalAttributes = 0;
-                            if (i < OriginalLodList[l].MeshList.Count() && j < OriginalLodList[l].MeshList[i].MeshInfo.MeshPartCount)
+                            try
                             {
-                                 originalAttributes = br.ReadInt32();
-                            }
+                                if (i < OriginalLodList[l].MeshList.Count() && j < OriginalLodList[l].MeshList[i].MeshInfo.MeshPartCount)
+                                {
+                                     originalAttributes = br.ReadInt32();
+                                }
 
-                            // Pull attributes from our import data.
-                            mp.Attributes = modelData.LoD[0].MeshList[i].MeshPartList[j].Attributes;
+                                // Pull attributes from our import data.
+                                mp.Attributes = modelData.LoD[0].MeshList[i].MeshPartList[j].Attributes;
+                            } catch(Exception e)
+                            {
+                                originalAttributes = 0;
+                                mp.Attributes = 0;
+                            }
 
                             // Make sure we can't be referencing attributes beyond the end of our attributes list.
                             //  It's a bitmask, where each bit references the attributes in order from the attribute strings

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -435,7 +435,14 @@ namespace FFXIV_TexTools2.IO
                                             }
                                             else
                                             {
-                                                pDict[meshNum].Add(int.Parse(num), cData);
+                                                int partNum = int.Parse(num);
+                                                pDict[meshNum].Add(partNum, cData);
+
+                                                while( partNum + 1 > modelData.LoD[0].MeshList[meshNum].MeshPartList.Count )
+                                                {
+                                                    var newPart = new MeshPart();
+                                                    modelData.LoD[0].MeshList[meshNum].MeshPartList.Add(newPart);
+                                                }
                                             }
 									    }
 									    catch (Exception e)
@@ -674,22 +681,10 @@ namespace FFXIV_TexTools2.IO
                     }
                 }
 
+                // For all imported meshes
                  for (int i = 0; i < pDict.Count; i++)
                  {
-                    // If the file has more meshes or mesh parts than the original model data did, create them.
                     var mDict = pDict[i];
-                    for (int l = 0; l < modelData.LoD.Count; l++)
-                    {
-                        for (int x = 0; x < modelData.LoD[l].MeshList.Count; x++)
-                        {
-                            while (modelData.LoD[l].MeshList[x].MeshPartList.Count() < mDict.Count())
-                            {
-                                MeshPart newPart = new MeshPart();
-                                modelData.LoD[l].MeshList[x].MeshPartList.Add(newPart);
-                            }
-                        }
-                    }
-                    
 
 
                     for (int j = 0; j < mDict.Count; j++)

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.8.2")]
+[assembly: AssemblyFileVersion("1.9.8.3")]

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.8.0")]
+[assembly: AssemblyFileVersion("1.9.8.2")]

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -98,6 +98,11 @@ namespace FFXIV_TexTools2.ViewModel
 
         public void UpdateModel(ItemData item, string category)
         {
+            if(item == null || category == null)
+            {
+                return;
+            }
+
             CompositeVM.Dispose();
             disposing = true;
             cbi.Clear();

--- a/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/TextureViewModel.cs
@@ -409,7 +409,7 @@ namespace FFXIV_TexTools2.ViewModel
                     }
                     else
                     {
-                        if (selectedCategory.Equals("UI"))
+                        if (selectedCategory.Equals("UI") || m.Name.Contains("Icon"))
                         {
                             texData = TEX.GetTex(offset, Strings.UIDat);
                         }

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8.2 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8.3 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8.2 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>


### PR DESCRIPTION
Been working with the discord to isolate and correct as many bugs as possible.  These are all the ones I could find that were safely fixable without potential side-effects.  I'm out of town for a month starting tomorrow, so wanted to safely fix as many bugs as possible before then.

- Fixed crash on closing Modlist with no item open. (Thanks Liinko)
- Fixed crash on using 'Save all DDS' option on an item with an Icon. (Thanks Upierczi)
- Fixed crash when importing certain Hair Models with more complex LoD1 models than LoD0 models. (Thanks Myopicat)
- Fixed dummy mesh parts being added to pad out mesh groups unnecessarily. (Thanks Alexstrasza)
- Fixed an error where 'Use Original Bones' would throw unnecessary warnings when used on faces.
- Added import warning when some Mesh Parts contain UV2 Data, but others do not.

Known Issues:
 - Skeleton files may need updating for some newer items. (Ex. Some Hairstyles and Bonewicca pieces)
 - 3D Face mods break Heterochromia (Vertex Color data is bashed)
