### PR TITLE
1.9.9.0 Provisional

### DIFF
--- a/FFXIV_TexTools2/App.config
+++ b/FFXIV_TexTools2/App.config
@@ -49,9 +49,12 @@
             <setting name="Etc_Color" serializeAs="String">
                 <value>#FF603913</value>
             </setting>
-          <setting name="BG_Color" serializeAs="String">
-            <value>#FF777777</value>
-          </setting>
+            <setting name="BG_Color" serializeAs="String">
+                <value>#FF777777</value>
+            </setting>
+            <setting name="DAE_Plugin_Target" serializeAs="String">
+                <value>Open Collada</value>
+            </setting>
         </FFXIV_TexTools2.Properties.Settings>
     </userSettings>
   <runtime>

--- a/FFXIV_TexTools2/FFXIV_TexTools2.csproj
+++ b/FFXIV_TexTools2/FFXIV_TexTools2.csproj
@@ -262,6 +262,9 @@
     <Compile Include="Views\MakeModPack.xaml.cs">
       <DependentUpon>MakeModPack.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Views\ExportSettings.xaml.cs">
+      <DependentUpon>ExportSettings.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Views\UISearch.xaml.cs">
       <DependentUpon>UISearch.xaml</DependentUpon>
     </Compile>
@@ -321,6 +324,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Views\MakeModPack.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\ExportSettings.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/FFXIV_TexTools2/FFXIV_TexTools2.csproj
+++ b/FFXIV_TexTools2/FFXIV_TexTools2.csproj
@@ -103,6 +103,7 @@
       <HintPath>..\packages\SharpDX.Mathematics.4.0.1\lib\net45\SharpDX.Mathematics.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />

--- a/FFXIV_TexTools2/FFXIV_TexTools2.csproj
+++ b/FFXIV_TexTools2/FFXIV_TexTools2.csproj
@@ -204,6 +204,7 @@
     <Compile Include="ViewModel\Composite3DViewModel.cs" />
     <Compile Include="ViewModel\ListViewModel.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />
+    <Compile Include="ViewModel\UISearchViewModel.cs" />
     <Compile Include="ViewModel\ModelSearchViewModel.cs" />
     <Compile Include="ViewModel\ModelViewModel.cs" />
     <Compile Include="ViewModel\ModListTVViewModel.cs" />
@@ -260,6 +261,9 @@
     </Compile>
     <Compile Include="Views\MakeModPack.xaml.cs">
       <DependentUpon>MakeModPack.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\UISearch.xaml.cs">
+      <DependentUpon>UISearch.xaml</DependentUpon>
     </Compile>
     <Compile Include="Views\ModelSearch.xaml.cs">
       <DependentUpon>ModelSearch.xaml</DependentUpon>
@@ -319,6 +323,10 @@
     <Page Include="Views\MakeModPack.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Views\UISearch.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\ModelSearch.xaml">
       <SubType>Designer</SubType>

--- a/FFXIV_TexTools2/FileTypes/MDL.cs
+++ b/FFXIV_TexTools2/FileTypes/MDL.cs
@@ -992,10 +992,10 @@ namespace FFXIV_TexTools2.Material
                             {
                                 br1.BaseStream.Seek(j * mesh.MeshInfo.VertexSizes[meshDataInfoList[colors].VertexDataBlock] + meshDataInfoList[colors].Offset, SeekOrigin.Begin);
 
-                                int a = br1.ReadByte();
                                 int r = br1.ReadByte();
                                 int g = br1.ReadByte();
                                 int b = br1.ReadByte();
+                                int a = br1.ReadByte();
 
                                 colorsList.Add(new Color4(r, g, b, a));
                             }

--- a/FFXIV_TexTools2/FileTypes/MDL.cs
+++ b/FFXIV_TexTools2/FileTypes/MDL.cs
@@ -77,8 +77,24 @@ namespace FFXIV_TexTools2.Material
             }
             else if (itemType.Equals("accessory"))
             {
-                MDLFolder = string.Format(Strings.AccMDLFolder, selectedItem.PrimaryModelID);
-                MDLFile = string.Format(Strings.AccMDLFile, selectedRace, selectedItem.PrimaryModelID, Info.slotAbr[selectedCategory]);
+                if (selectedCategory == Strings.Rings)
+                {
+                    MDLFolder = string.Format(Strings.AccMDLFolder, selectedItem.PrimaryModelID);
+                    if (selectedPart == Strings.Left)
+                    {
+                        MDLFile = string.Format(Strings.AccMDLFile, selectedRace, selectedItem.PrimaryModelID, Info.slotAbr[Strings.RingsLeft]);
+                    } else
+                    {
+                        MDLFile = string.Format(Strings.AccMDLFile, selectedRace, selectedItem.PrimaryModelID, Info.slotAbr[Strings.Rings]);
+
+                    }
+
+                }
+                else
+                {
+                    MDLFolder = string.Format(Strings.AccMDLFolder, selectedItem.PrimaryModelID);
+                    MDLFile = string.Format(Strings.AccMDLFile, selectedRace, selectedItem.PrimaryModelID, Info.slotAbr[selectedCategory]);
+                }
             }
             else if (itemType.Equals("character"))
             {

--- a/FFXIV_TexTools2/FileTypes/MTRL.cs
+++ b/FFXIV_TexTools2/FileTypes/MTRL.cs
@@ -1364,7 +1364,7 @@ namespace FFXIV_TexTools2.Material
             {
                 if (fileName.Contains("skin"))
                 {
-                    return Strings.Skin;
+                    return Strings.Specular;
                 }
                 else
                 {

--- a/FFXIV_TexTools2/FileTypes/MTRL.cs
+++ b/FFXIV_TexTools2/FileTypes/MTRL.cs
@@ -1030,7 +1030,7 @@ namespace FFXIV_TexTools2.Material
                     //}
 
 
-                    if (fileName.Contains("_s.tex") || fileName.Contains("skin"))
+                    if (fileName.Contains("_s.tex") || fileName.Contains("skin_m"))
                     {
                         mtrlInfo.SpecularPath = fullPath.Substring(0, fullPath.LastIndexOf("/")) + "/" + fileName;
                         mtrlInfo.TextureMaps.Add(new ComboBoxInfo() { Name = mapName, ID = "", IsNum = false });
@@ -1348,7 +1348,7 @@ namespace FFXIV_TexTools2.Material
         /// <returns>The texture map name</returns>
         private static string GetMapName(string fileName)
         {
-            if (fileName.Contains("_s.tex"))
+            if (fileName.Contains("_s.tex") || fileName.Contains("skin_m"))
             {
                 return Strings.Specular;
             }
@@ -1362,14 +1362,7 @@ namespace FFXIV_TexTools2.Material
             }
             else if (fileName.Contains("_m.tex"))
             {
-                if (fileName.Contains("skin"))
-                {
-                    return Strings.Specular;
-                }
-                else
-                {
-                    return Strings.Mask;
-                }
+                return Strings.Mask;
             }
             else
             {

--- a/FFXIV_TexTools2/FileTypes/MTRL.cs
+++ b/FFXIV_TexTools2/FileTypes/MTRL.cs
@@ -1246,8 +1246,17 @@ namespace FFXIV_TexTools2.Material
                 {
                     cbi.Add(new ComboBoxInfo() { Name = "Icon", ID = "Icon", IsNum = false });
                 }
-            }
-            else if (item.ItemCategory.Equals("HUD"))
+            } else if(item.ItemCategory.Equals(Strings.Other))
+            {
+                mtrlData.UIPath = item.UIPath + "/" + item.ItemName;
+                mtrlData.UIOffset = Helper.GetDataOffset(FFCRC.GetHash(item.UIPath), FFCRC.GetHash(item.ItemName), Strings.UIDat);
+
+                if (mtrlData.UIOffset != 0)
+                {
+                    cbi.Add(new ComboBoxInfo() { Name = "Icon", ID = "Icon", IsNum = false });
+                }
+
+            } else if (item.ItemCategory.Equals("HUD"))
             {
                 mtrlData.UIPath = item.UIPath;
                 var HUDFolder = "ui/uld";

--- a/FFXIV_TexTools2/Helpers/Helper.cs
+++ b/FFXIV_TexTools2/Helpers/Helper.cs
@@ -485,6 +485,11 @@ namespace FFXIV_TexTools2.Helpers
             return offset - (16 * datNum);
         }
 
+        public static float Clamp(float value, float min, float max)
+        {
+            return (value < min) ? min : (value > max) ? max : value;
+        }
+
         /// <summary>
         /// Gets the offset of the item data.
         /// </summary>

--- a/FFXIV_TexTools2/Helpers/Info.cs
+++ b/FFXIV_TexTools2/Helpers/Info.cs
@@ -50,6 +50,31 @@ namespace FFXIV_TexTools2.Helpers
             {Strings.UIDat, 2 }
         };
 
+        public static List<string> GearCategories = new List<string>
+        {
+            Strings.Main_Hand,
+            Strings.Off_Hand,
+            Strings.Head,
+            Strings.Body,
+            Strings.Hands,
+            Strings.Waist,
+            Strings.Legs,
+            Strings.Feet,
+            Strings.Ears,
+            Strings.Neck,
+            Strings.Wrists,
+            Strings.Rings,
+            Strings.Two_Handed,
+            Strings.Main_Off,
+            Strings.Head_Body,
+            Strings.Body_Hands_Legs_Feet,
+            Strings.Soul_Crystal,
+            Strings.Legs_Feet,
+            Strings.All,
+            Strings.Body_Hands_Legs,
+            Strings.Body_Legs_Feet
+        };
+
         public static ObservableCollection<string> SubCategoryList = new ObservableCollection<string>
         {
             Strings.Items, Strings.Maps, Strings.Actions, "HUD", Strings.Status

--- a/FFXIV_TexTools2/Helpers/Info.cs
+++ b/FFXIV_TexTools2/Helpers/Info.cs
@@ -186,7 +186,7 @@ namespace FFXIV_TexTools2.Helpers
             {Strings.Body_Hands_Legs, "top"},
             {Strings.Body_Legs_Feet, "top"},
             {Strings.Body_Hands_Legs_Feet, "top"},
-            {Strings.Legs_Feet, "top"},
+            {Strings.Legs_Feet, "dwn"},
             {Strings.All, "top"}
         };
 

--- a/FFXIV_TexTools2/Helpers/Info.cs
+++ b/FFXIV_TexTools2/Helpers/Info.cs
@@ -154,6 +154,7 @@ namespace FFXIV_TexTools2.Helpers
             {Strings.Ears, "ear"},
             {Strings.Neck, "nek"},
             {Strings.Rings, "rir"},
+            {Strings.RingsLeft, "ril"},
             {Strings.Wrists, "wrs"},
             {Strings.Head_Body, "top"},
             {Strings.Body_Hands, "top"},

--- a/FFXIV_TexTools2/Helpers/Info.cs
+++ b/FFXIV_TexTools2/Helpers/Info.cs
@@ -50,6 +50,12 @@ namespace FFXIV_TexTools2.Helpers
             {Strings.UIDat, 2 }
         };
 
+        public static List<string> DAEPluginTargets = new List<string>
+        {
+            Strings.OpenCollada,
+            Strings.AutodeskCollada
+        };
+
         public static List<string> GearCategories = new List<string>
         {
             Strings.Main_Hand,

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -409,6 +409,15 @@ namespace FFXIV_TexTools2.IO
                                             // Triangle Header precedes Index block,
                                             // And contains all our stride information.
                                             if (reader.Name.Equals("triangles")) {
+
+                                                // At this point we've read all of our original basic data, 
+                                                // so time to massage the data if the data sucks.
+                                                if(cData.texCoord2.Count == 0)
+                                                {
+                                                    // If we have no TexCoord2 data, just clone the TexCoord 1 data.
+                                                    cData.texCoord2.AddRange(cData.texCoord);
+                                                }
+
                                                 while(reader.Read())
                                                 {
                                                     if(reader.Name.Equals("input"))
@@ -485,7 +494,13 @@ namespace FFXIV_TexTools2.IO
 
 												}
 
-												break;
+                                                if (cData.tc2IndexList.Count == 0)
+                                                {
+                                                    // If we have no Tex2 Indices, clone the Tex1 Indexes (Code above copied in the Tex1 data).
+                                                    cData.tc2IndexList.AddRange(cData.tcIndexList);
+                                                }
+
+                                                break;
 											}
 										}
 									}
@@ -888,6 +903,7 @@ namespace FFXIV_TexTools2.IO
 						        cdDict[i].tangent.AddRange(mDict[c].tangent);
 						        cdDict[i].biNormal.AddRange(mDict[c].biNormal);
 
+                                // Rebuild the index list.
 						        for (int k = 0; k < mDict[c].vIndexList.Count; k++)
 						        {
 						            cdDict[i].index.Add(mDict[c].vIndexList[k] + vMax);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -454,7 +454,9 @@ namespace FFXIV_TexTools2.IO
 
                                                 if (cData.vertexColors.Count == 0)
                                                 {
-                                                    // If we have no VertexColor data, just add a single 1.0 value for everything.
+                                                    // If we have no VertexColor data, just add a 1.0 value for everything.
+                                                    cData.vertexColors.Add(1.0f);
+                                                    cData.vertexColors.Add(1.0f);
                                                     cData.vertexColors.Add(1.0f);
                                                 }
 
@@ -462,6 +464,11 @@ namespace FFXIV_TexTools2.IO
                                                 {
                                                     // If we have no VertexColor data, just add a single 1.0 value for everything.
                                                     cData.vertexAlphas.Add(1.0f);
+                                                    cData.vertexAlphas.Add(0.0f);
+                                                    if (tcStride == 3)
+                                                    {
+                                                        cData.vertexAlphas.Add(0.0f);
+                                                    }
                                                 }
 
                                                 while (reader.Read())
@@ -561,21 +568,23 @@ namespace FFXIV_TexTools2.IO
                                                     // If we have no Tex2 Indices, clone the Tex1 Indexes (Code above copied in the Tex1 data).
                                                     cData.tc2IndexList.AddRange(cData.tcIndexList);
                                                 }
+
                                                 if (cData.vcIndexList.Count == 0)
                                                 {
                                                     // If we have no Vertex Color Indices, initialize and set them to 0.
-                                                    var arr = new List<int>(cData.tcIndexList.Count);
-                                                    foreach(var idx in cData.tcIndexList)
+                                                    var arr = new List<int>(cData.vIndexList.Count);
+                                                    foreach(var idx in cData.vIndexList)
                                                     {
                                                         arr.Add(0);
                                                     }
                                                     cData.vcIndexList.AddRange(arr);
                                                 }
+
                                                 if (cData.vaIndexList.Count == 0)
                                                 {
                                                     // If we have no Vertex Alpha Indices, initialize and set them to 0.
-                                                    var arr = new List<int>(cData.tcIndexList.Count);
-                                                    foreach (var idx in cData.tcIndexList)
+                                                    var arr = new List<int>(cData.vIndexList.Count);
+                                                    foreach (var idx in cData.vIndexList)
                                                     {
                                                         arr.Add(0);
                                                     }
@@ -1122,36 +1131,24 @@ namespace FFXIV_TexTools2.IO
 						Normals.Add(new SharpDX.Vector3(cd.normal[i], cd.normal[i + 1], cd.normal[i + 2]));
 					}
 
-					if(cd.biNormal.Count > 0)
+					for (int i = 0; i < cd.biNormal.Count; i += 3)
 					{
-						for (int i = 0; i < cd.biNormal.Count; i += 3)
-						{
-							BiNormals.Add(new SharpDX.Vector3(cd.biNormal[i], cd.biNormal[i + 1], cd.biNormal[i + 2]));
-						}
+						BiNormals.Add(new SharpDX.Vector3(cd.biNormal[i], cd.biNormal[i + 1], cd.biNormal[i + 2]));
 					}
 
-					if (cd.tangent.Count > 0)
+					for (int i = 0; i < cd.tangent.Count; i += 3)
 					{
-						for (int i = 0; i < cd.tangent.Count; i += 3)
-						{
-							Tangents.Add(new SharpDX.Vector3(cd.tangent[i], cd.tangent[i + 1], cd.tangent[i + 2]));
-						}
+						Tangents.Add(new SharpDX.Vector3(cd.tangent[i], cd.tangent[i + 1], cd.tangent[i + 2]));
+					}
+
+                    for (int i = 0; i < cd.vertexColors.Count; i += 3)
+                    {
+                        VertexColors.Add(new SharpDX.Vector3(cd.vertexColors[i], cd.vertexColors[i + 1], cd.vertexColors[i + 2]));
                     }
 
-                    if (cd.vertexColors.Count > 0)
+                    for (int i = 0; i < cd.vertexAlphas.Count; i += tcStride)
                     {
-                        for (int i = 0; i < cd.vertexColors.Count; i += 3)
-                        {
-                            VertexColors.Add(new SharpDX.Vector3(cd.vertexColors[i], cd.vertexColors[i + 1], cd.vertexColors[i + 2]));
-                        }
-                    }
-
-                    if (cd.vertexAlphas.Count > 0)
-                    {
-                        for (int i = 0; i < cd.vertexAlphas.Count; i += tcStride)
-                        {
-                            VertexAlphas.Add(new SharpDX.Vector2(cd.vertexAlphas[i], cd.vertexAlphas[i + 1]));
-                        }
+                        VertexAlphas.Add(new SharpDX.Vector2(cd.vertexAlphas[i], cd.vertexAlphas[i + 1]));
                     }
 
                     for (int i = 0; i < cd.texCoord.Count; i += tcStride)

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -107,6 +107,7 @@ namespace FFXIV_TexTools2.IO
 
             importSettings = settings;
             var numMeshes = modelData.LoD[0].MeshCount;
+            modelData.Bones.Clear();
 
             var savePath = Properties.Settings.Default.Save_Directory + "/" + category + "/" + itemName + "/3D/" + modelName + ".DAE";
 
@@ -254,10 +255,10 @@ namespace FFXIV_TexTools2.IO
                 }
                 else
                 {
-                    for (int i = 0; i < modelData.Bones.Count; i++)
-                    {
-                        CustomBoneSet.Add(modelData.Bones[i], i);
-                    }
+                    //for (int i = 0; i < modelData.Bones.Count; i++)
+                    //{
+                        //CustomBoneSet.Add(modelData.Bones[i], i);
+                    //}
                 }
 
 				try
@@ -655,12 +656,12 @@ namespace FFXIV_TexTools2.IO
                         return;
                     }
 
-                    string boneString = "";
-                    foreach( string bone in extraBones )
-                    {
-                        boneString += bone + " ";
-                    }
-                    FlexibleMessageBox.Show("Bones not originally in this item were detected; TexTools will attempt to add them to the item.\n Bone(s): " + boneString, "ImportModel Notification " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    //boneString = "";
+                    //foreach( string bone in extraBones )
+                    //{
+                    //    boneString += bone + " ";
+                    //}
+                    //FlexibleMessageBox.Show("Bones not originally in this item were detected; TexTools will attempt to add them to the item.\n Bone(s): " + boneString, "ImportModel Notification " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 if (!importSettings[Strings.All].UseOriginalBones)
@@ -672,15 +673,11 @@ namespace FFXIV_TexTools2.IO
                         FlexibleMessageBox.Show("Item exceeds 64 Bone Limit.\nImport with 'Use Original Bones', or reduce bone count below 64.\n\nThe import has been cancelled.", "ImportModel Error " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                         return;
                     }
-                    int originalBonesLength = modelData.Bones.Count;
+                    //int originalBonesLength = modelData.Bones.Count;
                     for (int i = 0; i < CustomBoneSet.Count; i++)
                     {
                         // Add the extra bones into the bonestrings list.
-                        if (i >= modelData.Bones.Count)
-                        {
-                            modelData.Bones.Add(extraBones[i - originalBonesLength]);
-                        }
-
+                        modelData.Bones.Add(extraBones[i]);
                         modelData.BoneSet[0].BoneData[i] = i;
                     }
                 }

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -1278,8 +1278,6 @@ namespace FFXIV_TexTools2.IO
 
 					var extraVertDict = modelData.LoD[0].MeshList[m].extraVertDict;
 
-					Dictionary<int, int> indexDict = new Dictionary<int, int>();
-					var inCount = 0;
 
 					List<int> handedness = new List<int>();
 
@@ -1304,13 +1302,13 @@ namespace FFXIV_TexTools2.IO
 					{
 					    try
 					    {
-					        if (!indexDict.ContainsKey(iList[i][0]))
-					        {
-					            indexDict.Add(iList[i][0], inCount);
+					        //if (!indexDict.ContainsKey(iList[i][0]))
+					        //{
 
                                 // All data should be available at this point,
                                 // regardless of original source.
 
+                                // Build value-lists in the order we need them?
 					            nVertex.Add(Vertex[iList[i][0]]);
 					            nBlendIndices.Add(blendIndices[iList[i][0]]);
 					            nBlendWeights.Add(blendWeights[iList[i][0]]);
@@ -1322,8 +1320,7 @@ namespace FFXIV_TexTools2.IO
                                 nVertexColors.Add(VertexColors[iList[i][5]]);
                                 nVertexAlphas.Add(VertexAlphas[iList[i][6]]);
 
-					            inCount++;
-					        }
+					        //}
 					    }
 					    catch (Exception e)
 					    {
@@ -1342,8 +1339,8 @@ namespace FFXIV_TexTools2.IO
 					{
 					    try
 					    {
-					        var nIndex = indexDict[iList[i][0]];
-					        Indices.Add(nIndex);
+					        //var nIndex = indexDict[iList[i][0]];
+					        Indices.Add(i);
 					    }
 					    catch (Exception e)
 					    {
@@ -1417,8 +1414,8 @@ namespace FFXIV_TexTools2.IO
 					//    mg.Tangents = Tangents;
 					//}
 
-					SharpDX.Vector3[] tangents = new SharpDX.Vector3[Vertex.Count];
-					SharpDX.Vector3[] bitangents = new SharpDX.Vector3[Vertex.Count];
+					SharpDX.Vector3[] tangents = new SharpDX.Vector3[Indices.Count];
+					SharpDX.Vector3[] bitangents = new SharpDX.Vector3[Indices.Count];
 					for (int a = 0; a < Indices.Count; a += 3)
 					{
 						int idx1 = Indices[a];
@@ -1453,7 +1450,7 @@ namespace FFXIV_TexTools2.IO
 
 					float d;
 					SharpDX.Vector3 tmpt;
-					for (int a = 0; a < nVertex.Count; ++a)
+					for (int a = 0; a < Indices.Count; ++a)
 					{
 						SharpDX.Vector3 n = SharpDX.Vector3.Normalize(nNormals[a]);
 						SharpDX.Vector3 t = SharpDX.Vector3.Normalize(tangents[a]);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -799,12 +799,12 @@ namespace FFXIV_TexTools2.IO
                         return;
                     }
 
-                    var boneString = "";
+                    /*var boneString = "";
                     foreach( string bone in extraBones )
                     {
-                        boneString += bone + " ";
+                        boneString += bone + "\n";
                     }
-                    FlexibleMessageBox.Show("Bones not originally in this item were detected; TexTools will attempt to add them to the item.\n Bone(s): " + boneString, "ImportModel Notification " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    FlexibleMessageBox.Show("Bones not originally in this item were detected; TexTools will attempt to add them to the item.\n Bone(s):\n " + boneString, "ImportModel Notification " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Information);*/
                 }
 
                 if (!importSettings[Strings.All].UseOriginalBones)

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -1426,7 +1426,7 @@ namespace FFXIV_TexTools2.IO
                     // Go ahead and distill this down into just the single value we care about.
                     foreach (var uv3Coordinate in nVertexAlphas)
                     {
-                        cmd.vertexAlphas.Add(uv3Coordinate.X);
+                        cmd.vertexAlphas.Add(Helper.Clamp(uv3Coordinate.X, 0, 1));
                     }
 
 					cmdList.Add(cmd);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -368,7 +368,7 @@ namespace FFXIV_TexTools2.IO
 
                                     var meshNum = int.Parse(atr.Substring(atr.LastIndexOf("_") + 1, 1));
 
-									if (atr.Contains("."))
+                                    if (atr.Contains("."))
 									{
                                         try
                                         {
@@ -377,7 +377,7 @@ namespace FFXIV_TexTools2.IO
                                         {
 
                                         }
-									}
+                                    }
 
 									var cData = new ColladaData();
 
@@ -982,7 +982,6 @@ namespace FFXIV_TexTools2.IO
                                         + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }
 
-
                                 if (maxTexCoord2 > mDict[c].texCoord2.Count())
                                 {
                                     FlexibleMessageBox.Show("The following mesh part references UV2 Data which does not exist in the file:\nMesh: " + i + " Part: " + j
@@ -990,21 +989,39 @@ namespace FFXIV_TexTools2.IO
                                         + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
                                 }
 
-                                
+                                if (maxVertColor > mDict[c].vertexColors.Count())
+                                {
+                                    FlexibleMessageBox.Show("The following mesh part references Vertex Color Data which does not exist in the file:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+                                if (maxVertAlpha > mDict[c].vertexAlphas.Count())
+                                {
+                                    FlexibleMessageBox.Show("The following mesh part references Vertex Alpha(UV3) Data which does not exist in the file:\nMesh: " + i + " Part: " + j
+                                        + "\n\nThis has a chance of either crashing TexTools or causing other errors in the import."
+                                        + "\n\nThe import will now attempt to continue.", "ImportModel Warning " + Info.appVersion, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                                }
+
+
+
 
                                 // All meshes should have data for all fields at this point.
                                 // Either the DAE had valid data, or we dummied it up.
-                                
+
                                 // If the data lengths were mismatched, we at least threw a warning.
 
-                                cdDict[i].vertex.AddRange(mDict[c].vertex);
-						        cdDict[i].normal.AddRange(mDict[c].normal);
-						        cdDict[i].texCoord.AddRange(mDict[c].texCoord);
-						        cdDict[i].texCoord2.AddRange(mDict[c].texCoord2);
-						        cdDict[i].tangent.AddRange(mDict[c].tangent);
-						        cdDict[i].biNormal.AddRange(mDict[c].biNormal);
-                                cdDict[i].vertexColors.AddRange(mDict[c].vertexColors);
-                                cdDict[i].vertexAlphas.AddRange(mDict[c].vertexAlphas);
+                                // Appropriate amount of values is 
+                                // ( [ Highest reference from indices ] + 1 )* [ entries per index ] ) + 
+
+                                cdDict[i].vertex.AddRange(mDict[c].vertex.Take((mDict[c].vIndexList.Max() + 1) * 3 ));
+						        cdDict[i].normal.AddRange(mDict[c].normal.Take((mDict[c].nIndexList.Max() + 1) * 3));
+						        cdDict[i].texCoord.AddRange(mDict[c].texCoord.Take((mDict[c].tcIndexList.Max() + 1) * tcStride ));
+						        cdDict[i].texCoord2.AddRange(mDict[c].texCoord2.Take((mDict[c].tc2IndexList.Max() + 1) * tcStride ));
+						        cdDict[i].tangent.AddRange(mDict[c].tangent.Take((mDict[c].bnIndexList.Max() + 1) * 3));
+						        cdDict[i].biNormal.AddRange(mDict[c].biNormal.Take((mDict[c].bnIndexList.Max() + 1) * 3));
+                                cdDict[i].vertexColors.AddRange(mDict[c].vertexColors.Take((mDict[c].vcIndexList.Max() + 1) * 3));
+                                cdDict[i].vertexAlphas.AddRange(mDict[c].vertexAlphas.Take((mDict[c].vaIndexList.Max() + 1) * tcStride ));
 
                                 // Rebuild the index list.
                                 for (int k = 0; k < mDict[c].vIndexList.Count; k++)

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -3218,22 +3218,27 @@ namespace FFXIV_TexTools2.IO
                                 // Which bone we used to reference,
                                 // and then which new bone we should reference after
                                 // altering the bone list.
-                                for(var idx = 0; idx < extraVerts; idx++)
+
+                                importDict[extraLoc].dataSet1.AddRange(maskVerts);
+                                /*
+                                for (var idx = 0; idx < extraVerts; idx++)
                                 {
-                                    var extraVertOffset = idx * meshInfo.VertexSizes[0];
+                                    var vsize = meshInfo.VertexSizes[0];
+                                    var extraVertOffset = idx * vsize;
                                     
                                     // The first 16 bytes are the same.
-                                    importDict[extraLoc].dataSet1.AddRange(maskVerts.Skip(20 * idx).Take(16));
+                                    importDict[extraLoc].dataSet1.AddRange(maskVerts.Skip(vsize * idx).Take(vsize));
 
                                     // The bone indices may need to be changed...
                                     // This is probably too complex of a task currently 
                                     // to do in this update (1.9.8.5)
+                                    
                                     for(var i = 0; i < 4; i++)
                                     {
                                         var oldBoneIndex = maskVerts[16 + i];
                                         importDict[extraLoc].dataSet1.Add(oldBoneIndex);
                                     }
-                                }
+                                }*/
 
                             }
                         }

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -3788,7 +3788,7 @@ namespace FFXIV_TexTools2.IO
 		    else
 		    {
 		        var fileLength = new FileInfo(modDatPath).Length;
-		        while (fileLength >= 2000000000)
+		        while (fileLength + data.Count >= 2000000000)
 		        {
 		            datNum += 1;
 		            modDatPath = string.Format(Info.datDir, Strings.ItemsDat, datNum);

--- a/FFXIV_TexTools2/IO/ImportTex.cs
+++ b/FFXIV_TexTools2/IO/ImportTex.cs
@@ -638,7 +638,7 @@ namespace FFXIV_TexTools2.IO
             else
             {
                 var fileLength = new FileInfo(modDatPath).Length;
-                while (fileLength >= 2000000000)
+                while (fileLength + data.Count >= 2000000000)
                 {
                     datNum += 1;
                     modDatPath = string.Format(Info.datDir, datName, datNum);

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -1386,6 +1386,78 @@ namespace FFXIV_TexTools2.IO
 
                             /*
                              * --------------------
+                             * Vertex Colors
+                             * --------------------
+                             */
+
+                            //<source>
+                            xmlWriter.WriteStartElement("source");
+                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-col0");
+                            //<float_array>
+                            xmlWriter.WriteStartElement("float_array");
+                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-col0-array");
+                            xmlWriter.WriteAttributeString("count", (totalCount * 3).ToString());
+                            
+                            var vertexColors = meshList[i].VertexColors.GetRange(totalVertices, totalCount);
+
+                            foreach (var vc in vertexColors)
+                            {
+                                float r = vc.Red / 255.0f;
+                                float g = vc.Green / 255.0f;
+                                float b = vc.Blue / 255.0f;
+                                //float a = vc.Alpha / 255.0f;
+
+                                xmlWriter.WriteString(r.ToString() + " " + g.ToString() + " " + b.ToString() + " ");
+                            }
+
+                            xmlWriter.WriteEndElement();
+                            //</float_array>
+
+                            //<technique_common>
+                            xmlWriter.WriteStartElement("technique_common");
+                            //<accessor>
+                            xmlWriter.WriteStartElement("accessor");
+                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0-array");
+                            xmlWriter.WriteAttributeString("count", totalCount.ToString());
+                            xmlWriter.WriteAttributeString("stride", "4");
+
+                            //<param>
+                            xmlWriter.WriteStartElement("param");
+                            xmlWriter.WriteAttributeString("name", "R");
+                            xmlWriter.WriteAttributeString("type", "float");
+                            xmlWriter.WriteEndElement();
+                            //</param>
+
+                            //<param>
+                            xmlWriter.WriteStartElement("param");
+                            xmlWriter.WriteAttributeString("name", "G");
+                            xmlWriter.WriteAttributeString("type", "float");
+                            xmlWriter.WriteEndElement();
+                            //</param>
+
+                            //<param>
+                            xmlWriter.WriteStartElement("param");
+                            xmlWriter.WriteAttributeString("name", "B");
+                            xmlWriter.WriteAttributeString("type", "float");
+                            xmlWriter.WriteEndElement();
+                            //</param>
+
+                            //<param>
+                            /*xmlWriter.WriteStartElement("param");
+                            xmlWriter.WriteAttributeString("name", "A");
+                            xmlWriter.WriteAttributeString("type", "float");
+                            xmlWriter.WriteEndElement();*/
+                            //</param>
+
+                            xmlWriter.WriteEndElement();
+                            //</accessor>
+                            xmlWriter.WriteEndElement();
+                            //</technique_common>
+                            xmlWriter.WriteEndElement();
+                            //</source>
+
+                            /*
+                             * --------------------
                              * Texture Coordinates
                              * --------------------
                              */
@@ -1470,6 +1542,62 @@ namespace FFXIV_TexTools2.IO
                             //<accessor>
                             xmlWriter.WriteStartElement("accessor");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map1-array");
+                            xmlWriter.WriteAttributeString("count", totalCount.ToString());
+                            xmlWriter.WriteAttributeString("stride", "2");
+
+                            //<param>
+                            xmlWriter.WriteStartElement("param");
+                            xmlWriter.WriteAttributeString("name", "S");
+                            xmlWriter.WriteAttributeString("type", "float");
+                            xmlWriter.WriteEndElement();
+                            //</param>
+
+                            //<param>
+                            xmlWriter.WriteStartElement("param");
+                            xmlWriter.WriteAttributeString("name", "T");
+                            xmlWriter.WriteAttributeString("type", "float");
+                            xmlWriter.WriteEndElement();
+                            //</param>
+
+                            xmlWriter.WriteEndElement();
+                            //</accessor>
+                            xmlWriter.WriteEndElement();
+                            //</technique_common>
+                            xmlWriter.WriteEndElement();
+                            //</source>
+
+                            /*
+                             * --------------------
+                             * Vertex Opacity - UV Work-Around
+                             * --------------------
+                             */
+
+                            //<source>
+                            xmlWriter.WriteStartElement("source");
+                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-map2");
+                            //<float_array>
+                            xmlWriter.WriteStartElement("float_array");
+                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-map2-array");
+                            xmlWriter.WriteAttributeString("count", (totalCount * 2).ToString());
+
+                            vertexColors = meshList[i].VertexColors.GetRange(totalVertices, totalCount);
+
+                            foreach (var vc in vertexColors)
+                            {
+                                float a = vc.Alpha / 255.0f;
+
+                                // Use the UV S channel for the Alpha data, since OpenCollada doesn't play with it nicely.
+                                xmlWriter.WriteString(a.ToString() + " 0 ");
+                            }
+
+                            xmlWriter.WriteEndElement();
+                            //</float_array>
+
+                            //<technique_common>
+                            xmlWriter.WriteStartElement("technique_common");
+                            //<accessor>
+                            xmlWriter.WriteStartElement("accessor");
+                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2-array");
                             xmlWriter.WriteAttributeString("count", totalCount.ToString());
                             xmlWriter.WriteAttributeString("stride", "2");
 
@@ -1653,6 +1781,14 @@ namespace FFXIV_TexTools2.IO
 
                             //<input>
                             xmlWriter.WriteStartElement("input");
+                            xmlWriter.WriteAttributeString("semantic", "COLOR");
+                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0");
+                            xmlWriter.WriteAttributeString("offset", "2");
+                            xmlWriter.WriteEndElement();
+                            //</input>
+
+                            //<input>
+                            xmlWriter.WriteStartElement("input");
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map0");
                             xmlWriter.WriteAttributeString("offset", "2");
@@ -1666,6 +1802,14 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map1");
                             xmlWriter.WriteAttributeString("offset", "2");
                             xmlWriter.WriteAttributeString("set", "1");
+                            xmlWriter.WriteEndElement();
+                            //</input>
+
+                            //<input>
+                            xmlWriter.WriteStartElement("input");
+                            xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
+                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2");
+                            xmlWriter.WriteAttributeString("offset", "2");
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1713,468 +1857,6 @@ namespace FFXIV_TexTools2.IO
                         }
                     }
                 }
-
-                #region testing
-                //if (modelData.ExtraData.totalExtraCounts.ContainsKey(i))
-                //{
-                //    var extraVerts = modelData.ExtraData.totalExtraCounts[i];
-                //    var extraStart = meshList[i].Indices.Max() + 1;
-
-                //    //<geometry>
-                //    xmlWriter.WriteStartElement("geometry");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i);
-                //    xmlWriter.WriteAttributeString("name", "extra_" + modelName + "_" + i);
-                //    //<mesh>
-                //    xmlWriter.WriteStartElement("mesh");
-
-                //    /*
-                //     * --------------------
-                //     * Verticies
-                //     * --------------------
-                //     */
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-positions");
-                //    //<float_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-positions-array");
-                //    xmlWriter.WriteAttributeString("count", (extraVerts * 3).ToString());
-
-                //    var ExPositions = meshList[i].Vertices.GetRange(extraStart, extraVerts);
-
-                //    foreach (var v in ExPositions)
-                //    {
-                //        xmlWriter.WriteString((v.X * Info.modelMultiplier).ToString() + " " + (v.Y * Info.modelMultiplier).ToString() + " " + (v.Z * Info.modelMultiplier).ToString() + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</float_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-positions-array");
-                //    xmlWriter.WriteAttributeString("count", extraVerts.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "3");
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "X");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Y");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Z");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-
-                //    /*
-                //     * --------------------
-                //     * Normals
-                //     * --------------------
-                //     */
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-normals");
-                //    //<float_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-normals-array");
-                //    xmlWriter.WriteAttributeString("count", (extraVerts * 3).ToString());
-
-                //    var ExNormals = meshList[i].Normals.GetRange(extraStart, extraVerts);
-
-                //    foreach (var n in ExNormals)
-                //    {
-                //        xmlWriter.WriteString(n.X.ToString() + " " + n.Y.ToString() + " " + n.Z.ToString() + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</float_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-normals-array");
-                //    xmlWriter.WriteAttributeString("count", extraVerts.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "3");
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "X");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Y");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Z");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-                //    /*
-                //     * --------------------
-                //     * Texture Coordinates
-                //     * --------------------
-                //     */
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map0");
-                //    //<float_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map0-array");
-                //    xmlWriter.WriteAttributeString("count", (extraVerts * 2).ToString());
-
-                //    //var texCoords = meshList[i].TextureCoordinates.GetRange(totalVertices, totalCount);
-                //    var ExTexCoords = meshList[i].TextureCoordinates.GetRange(extraStart, extraVerts);
-
-                //    foreach (var tc in ExTexCoords)
-                //    {
-                //        xmlWriter.WriteString(tc.X.ToString() + " " + (tc.Y * -1).ToString() + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</float_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map0-array");
-                //    xmlWriter.WriteAttributeString("count", extraVerts.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "2");
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "S");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "T");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-                //    /*
-                //     * --------------------
-                //     * Seconadry Texture Coordinates
-                //     * --------------------
-                //     */
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map1");
-                //    //<float_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map1-array");
-                //    xmlWriter.WriteAttributeString("count", (extraVerts * 2).ToString());
-
-                //    //var texCoords = meshList[i].TextureCoordinates.GetRange(totalVertices, totalCount);
-                //    var ExTexCoords2 = meshList[i].TextureCoordinates2.GetRange(extraStart, extraVerts);
-
-                //    foreach (var tc in ExTexCoords2)
-                //    {
-                //        xmlWriter.WriteString(tc.X.ToString() + " " + (tc.Y * -1).ToString() + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</float_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map1-array");
-                //    xmlWriter.WriteAttributeString("count", extraVerts.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "2");
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "S");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "T");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-                //    /*
-                //     * --------------------
-                //     * Tangents
-                //     * --------------------
-                //     */
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map0-textangents");
-                //    //<float_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map0-textangents-array");
-                //    xmlWriter.WriteAttributeString("count", (extraVerts * 3).ToString());
-
-                //    var ExTangents = meshList[i].Tangents.GetRange(extraStart, extraVerts);
-
-                //    foreach (var tan in ExTangents)
-                //    {
-                //        xmlWriter.WriteString(tan.X.ToString() + " " + tan.Y.ToString() + " " + tan.Z.ToString() + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</float_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map0-textangents-array");
-                //    xmlWriter.WriteAttributeString("count", extraVerts.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "3");
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "X");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Y");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Z");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-
-                //    /*
-                //     * --------------------
-                //     * Binormals
-                //     * --------------------
-                //     */
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map0-texbinormals");
-                //    //<float_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-map0-texbinormals-array");
-                //    xmlWriter.WriteAttributeString("count", (extraVerts * 3).ToString());
-
-                //    var ExBiNormals = meshList[i].BiTangents.GetRange(extraStart, extraVerts);
-
-                //    foreach (var bn in ExBiNormals)
-                //    {
-                //        xmlWriter.WriteString(bn.X.ToString() + " " + bn.Y.ToString() + " " + bn.Z.ToString() + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</float_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map0-texbinormals-array");
-                //    xmlWriter.WriteAttributeString("count", extraVerts.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "3");
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "X");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Y");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "Z");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-
-                //    //<vertices>
-                //    xmlWriter.WriteStartElement("vertices");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-vertices");
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "POSITION");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-positions");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-                //    xmlWriter.WriteEndElement();
-                //    //</vertices>
-
-                //    var extraIndexCount = 0;
-                //    foreach (var ic in modelData.ExtraData.indexCounts)
-                //    {
-                //        extraIndexCount += ic.IndexCount;
-                //    }
-
-                //    //<triangles>
-                //    xmlWriter.WriteStartElement("triangles");
-                //    xmlWriter.WriteAttributeString("material", modelName + "_" + i);
-                //    xmlWriter.WriteAttributeString("count", (modelData.ExtraData.extraIndices[i].Count / 3).ToString());
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "VERTEX");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-vertices");
-                //    xmlWriter.WriteAttributeString("offset", "0");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "NORMAL");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-normals");
-                //    xmlWriter.WriteAttributeString("offset", "1");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map0");
-                //    xmlWriter.WriteAttributeString("offset", "2");
-                //    xmlWriter.WriteAttributeString("set", "0");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map1");
-                //    xmlWriter.WriteAttributeString("offset", "2");
-                //    xmlWriter.WriteAttributeString("set", "1");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "TEXTANGENT");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map0-textangents");
-                //    xmlWriter.WriteAttributeString("offset", "3");
-                //    xmlWriter.WriteAttributeString("set", "1");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "TEXBINORMAL");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-map0-texbinormals");
-                //    xmlWriter.WriteAttributeString("offset", "3");
-                //    xmlWriter.WriteAttributeString("set", "1");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<p>
-                //    xmlWriter.WriteStartElement("p");
-                //    var minIndex = modelData.ExtraData.extraIndices[i].Min();
-                //    foreach (var ind in modelData.ExtraData.extraIndices[i])
-                //    {
-                //        int p = ind - minIndex;
-
-                //        if (p >= 0)
-                //        {
-                //            xmlWriter.WriteString(p + " " + p + " " + p + " " + p + " ");
-                //        }
-                //    }
-                //    xmlWriter.WriteEndElement();
-                //    //</p>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</triangles>
-                //    xmlWriter.WriteEndElement();
-                //    //</mesh>
-                //    xmlWriter.WriteEndElement();
-                //    //</geometry>
-                //}
-                #endregion testing
             }
 
             xmlWriter.WriteEndElement();
@@ -2453,226 +2135,6 @@ namespace FFXIV_TexTools2.IO
                         }
                     }
                 }
-
-                #region testing
-                //if (modelData.ExtraData.totalExtraCounts.ContainsKey(i))
-                //{
-                //    //< controller >
-                //    xmlWriter.WriteStartElement("controller");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1");
-                //    //<skin>
-                //    xmlWriter.WriteStartElement("skin");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i);
-                //    //<bind_shape_matrix>
-                //    xmlWriter.WriteStartElement("bind_shape_matrix");
-                //    xmlWriter.WriteString("1 0 0 0 0 1 0 0 0 0 1 0 0 0 0 1");
-                //    xmlWriter.WriteEndElement();
-                //    //</bind_shape_matrix>
-
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1-joints");
-                //    //<Name_array>
-                //    xmlWriter.WriteStartElement("Name_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1-joints-array");
-                //    xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
-                //    foreach (var b in meshDataList[i].BoneStrings)
-                //    {
-                //        xmlWriter.WriteString(b + " ");
-                //    }
-                //    xmlWriter.WriteEndElement();
-                //    //</Name_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-joints-array");
-                //    xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "1");
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "JOINT");
-                //    xmlWriter.WriteAttributeString("type", "name");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1-bind_poses");
-                //    //<Name_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1-bind_poses-array");
-                //    xmlWriter.WriteAttributeString("count", (16 * meshDataList[i].BoneStrings.Count).ToString());
-
-                //    for (int m = 0; m < meshDataList[i].BoneStrings.Count; m++)
-                //    {
-                //        try
-                //        {
-                //            Matrix matrix = new Matrix(skelDict[meshDataList[i].BoneStrings[m]].InversePoseMatrix);
-
-                //            xmlWriter.WriteString(matrix.Column1.X + " " + matrix.Column1.Y + " " + matrix.Column1.Z + " " + (matrix.Column1.W * Info.modelMultiplier) + " ");
-                //            xmlWriter.WriteString(matrix.Column2.X + " " + matrix.Column2.Y + " " + matrix.Column2.Z + " " + (matrix.Column2.W * Info.modelMultiplier) + " ");
-                //            xmlWriter.WriteString(matrix.Column3.X + " " + matrix.Column3.Y + " " + matrix.Column3.Z + " " + (matrix.Column3.W * Info.modelMultiplier) + " ");
-                //            xmlWriter.WriteString(matrix.Column4.X + " " + matrix.Column4.Y + " " + matrix.Column4.Z + " " + (matrix.Column4.W * Info.modelMultiplier) + " ");
-                //        }
-                //        catch
-                //        {
-                //            Debug.WriteLine("Error at " + meshDataList[i].BoneStrings[m]);
-                //        }
-
-                //    }
-                //    xmlWriter.WriteEndElement();
-                //    //</Name_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-bind_poses-array");
-                //    xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "16");
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "TRANSFORM");
-                //    xmlWriter.WriteAttributeString("type", "float4x4");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-                //    var extraVerts = modelData.ExtraData.totalExtraCounts[i];
-                //    //var extraStart = meshDataList[i].Indices.Max() + 1;
-                //    var extraStart = modelData.ExtraData.indexMin[i];
-                //    var ExWeightCounts = meshDataList[i].WeightCounts.GetRange(extraStart, extraVerts);
-                //    var totalExWeights = 0;
-
-                //    foreach (var bwc in ExWeightCounts)
-                //    {
-                //        totalExWeights += bwc;
-                //    }
-
-                //    //<source>
-                //    xmlWriter.WriteStartElement("source");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1-weights");
-                //    //<Name_array>
-                //    xmlWriter.WriteStartElement("float_array");
-                //    xmlWriter.WriteAttributeString("id", "geom-extra_" + modelName + "_" + i + "-skin1-weights-array");
-                //    xmlWriter.WriteAttributeString("count", totalExWeights.ToString());
-
-                //    var ExWeightlist = meshDataList[i].BlendWeights.GetRange(extraStart, totalExWeights);
-
-                //    foreach (var bw in ExWeightlist)
-                //    {
-                //        xmlWriter.WriteString(bw + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</Name_array>
-
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<accessor>
-                //    xmlWriter.WriteStartElement("accessor");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-weights-array");
-                //    xmlWriter.WriteAttributeString("count", totalExWeights.ToString());
-                //    xmlWriter.WriteAttributeString("stride", "1");
-                //    //<param>
-                //    xmlWriter.WriteStartElement("param");
-                //    xmlWriter.WriteAttributeString("name", "WEIGHT");
-                //    xmlWriter.WriteAttributeString("type", "float");
-                //    xmlWriter.WriteEndElement();
-                //    //</param>
-                //    xmlWriter.WriteEndElement();
-                //    //</accessor>
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>
-                //    xmlWriter.WriteEndElement();
-                //    //</source>
-
-                //    //<joints>
-                //    xmlWriter.WriteStartElement("joints");
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "JOINT");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-joints");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "INV_BIND_MATRIX");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-bind_poses");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-                //    xmlWriter.WriteEndElement();
-                //    //</joints>
-
-                //    //<vertex_weights>
-                //    xmlWriter.WriteStartElement("vertex_weights");
-                //    xmlWriter.WriteAttributeString("count", ExWeightlist.Count.ToString());
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "JOINT");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-joints");
-                //    xmlWriter.WriteAttributeString("offset", "0");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-                //    //<input>
-                //    xmlWriter.WriteStartElement("input");
-                //    xmlWriter.WriteAttributeString("semantic", "WEIGHT");
-                //    xmlWriter.WriteAttributeString("source", "#geom-extra_" + modelName + "_" + i + "-skin1-weights");
-                //    xmlWriter.WriteAttributeString("offset", "1");
-                //    xmlWriter.WriteEndElement();
-                //    //</input>
-
-                //    //<vcount>
-                //    xmlWriter.WriteStartElement("vcount");
-
-                //    //var ExWeightlist = meshDataList[i].WeightCounts.GetRange(extraStart, totalExWeights);
-
-                //    foreach (var bwc in ExWeightCounts)
-                //    {
-                //        xmlWriter.WriteString(bwc + " ");
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</vcount>
-                //    //<v>
-                //    xmlWriter.WriteStartElement("v");
-                //    int blin2 = 0;
-
-                //    var ExBlendind = meshDataList[i].BlendIndices.GetRange(extraStart, totalExWeights);
-
-                //    foreach (var bi in ExBlendind)
-                //    {
-                //        xmlWriter.WriteString(bi + " " + blin2 + " ");
-                //        blin2++;
-                //    }
-
-                //    xmlWriter.WriteEndElement();
-                //    //</v>
-                //    xmlWriter.WriteEndElement();
-                //    //</vertex_weights>
-
-                //    xmlWriter.WriteEndElement();
-                //    //</skin>
-                //    xmlWriter.WriteEndElement();
-                //    //</controller>
-                //}
-                #endregion testing
             }
 
             xmlWriter.WriteEndElement();
@@ -2766,55 +2228,6 @@ namespace FFXIV_TexTools2.IO
                     xmlWriter.WriteEndElement();
                     //</node>
                 }
-
-                #region testing
-                //if (modelData.ExtraData.totalExtraCounts.ContainsKey(i))
-                //{
-                //    //<node>
-                //    xmlWriter.WriteStartElement("node");
-                //    xmlWriter.WriteAttributeString("id", "node-extra_" + modelName + "_" + i);
-                //    xmlWriter.WriteAttributeString("name", "extra_" + modelName + "_" + i);
-
-                //    //<instance_controller>
-                //    xmlWriter.WriteStartElement("instance_controller");
-                //    xmlWriter.WriteAttributeString("url", "#geom-extra_" + modelName + "_" + i + "-skin1");
-
-                //    foreach (var b in boneParents)
-                //    {
-                //        //<skeleton> 
-                //        xmlWriter.WriteStartElement("skeleton");
-                //        xmlWriter.WriteString("#node-" + b);
-                //        xmlWriter.WriteEndElement();
-                //        //</skeleton> 
-                //    }
-
-                //    //<bind_material>
-                //    xmlWriter.WriteStartElement("bind_material");
-                //    //<technique_common>
-                //    xmlWriter.WriteStartElement("technique_common");
-                //    //<instance_material>
-                //    xmlWriter.WriteStartElement("instance_material");
-                //    xmlWriter.WriteAttributeString("symbol", modelName + "_" + i);
-                //    xmlWriter.WriteAttributeString("target", "#" + modelName + "_" + i + "-material");
-                //    //<bind_vertex_input>
-                //    xmlWriter.WriteStartElement("bind_vertex_input");
-                //    xmlWriter.WriteAttributeString("semantic", "geom-" + modelName + "_" + i + "-map1");
-                //    xmlWriter.WriteAttributeString("input_semantic", "TEXCOORD");
-                //    xmlWriter.WriteAttributeString("input_set", "0");
-                //    xmlWriter.WriteEndElement();
-                //    //</bind_vertex_input>   
-                //    xmlWriter.WriteEndElement();
-                //    //</instance_material>       
-                //    xmlWriter.WriteEndElement();
-                //    //</technique_common>            
-                //    xmlWriter.WriteEndElement();
-                //    //</bind_material>   
-                //    xmlWriter.WriteEndElement();
-                //    //</instance_controller>
-                //    xmlWriter.WriteEndElement();
-                //    //</node>
-                //}
-                #endregion testing
 
                 xmlWriter.WriteEndElement();
                 //</node>

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -1419,7 +1419,7 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteStartElement("accessor");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0-array");
                             xmlWriter.WriteAttributeString("count", totalCount.ToString());
-                            xmlWriter.WriteAttributeString("stride", "4");
+                            xmlWriter.WriteAttributeString("stride", "3");
 
                             //<param>
                             xmlWriter.WriteStartElement("param");
@@ -1568,7 +1568,7 @@ namespace FFXIV_TexTools2.IO
 
                             /*
                              * --------------------
-                             * Vertex Opacity - UV Work-Around
+                             * Vertex Alpha - UV Work-Around
                              * --------------------
                              */
 

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -774,6 +774,12 @@ namespace FFXIV_TexTools2.IO
             xmlWriter.WriteStartElement("authoring_tool");
             xmlWriter.WriteString("FFXIV TexTools2");
             xmlWriter.WriteEndElement();
+            xmlWriter.WriteStartElement("tool_settings");
+            xmlWriter.WriteString(Properties.Settings.Default.DAE_Plugin_Target);
+            xmlWriter.WriteEndElement();
+            xmlWriter.WriteStartElement("tool_version");
+            xmlWriter.WriteString(Info.appVersion);
+            xmlWriter.WriteEndElement();
             //</authoring_tool>
             xmlWriter.WriteEndElement();
             //</contributor>
@@ -1136,9 +1142,13 @@ namespace FFXIV_TexTools2.IO
                     //</texture>
                     xmlWriter.WriteEndElement();
                     //</specular>
+
                     //<transparent>
                     xmlWriter.WriteStartElement("transparent");
-                    xmlWriter.WriteAttributeString("opaque", "A_ONE");
+
+                    xmlWriter.WriteAttributeString("opaque", "RGB_ZERO");
+
+
                     //<texture>
                     xmlWriter.WriteStartElement("texture");
                     xmlWriter.WriteAttributeString("texture", modelName + "_" + i + "_Alpha_bmp-sampler");
@@ -1223,6 +1233,8 @@ namespace FFXIV_TexTools2.IO
 
         private static void XMLgeometries(XmlWriter xmlWriter, string modelName, List<ModelMeshData> meshList, ModelData modelData)
         {
+            var pluginTarget = Properties.Settings.Default.DAE_Plugin_Target;
+
             //<library_geometries>
             xmlWriter.WriteStartElement("library_geometries");
 
@@ -1796,7 +1808,14 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map0");
                             xmlWriter.WriteAttributeString("offset", "2");
-                            xmlWriter.WriteAttributeString("set", "1");
+                            if(pluginTarget == Strings.AutodeskCollada)
+                            {
+                                xmlWriter.WriteAttributeString("set", "0");
+
+                            } else
+                            {
+                                xmlWriter.WriteAttributeString("set", "1");
+                            }
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1805,7 +1824,15 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map1");
                             xmlWriter.WriteAttributeString("offset", "2");
-                            xmlWriter.WriteAttributeString("set", "2");
+                            if (pluginTarget == Strings.AutodeskCollada)
+                            {
+                                xmlWriter.WriteAttributeString("set", "1");
+
+                            }
+                            else
+                            {
+                                xmlWriter.WriteAttributeString("set", "2");
+                            }
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1814,7 +1841,15 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2");
                             xmlWriter.WriteAttributeString("offset", "2");
-                            xmlWriter.WriteAttributeString("set", "3");
+                            if (pluginTarget == Strings.AutodeskCollada)
+                            {
+                                xmlWriter.WriteAttributeString("set", "2");
+
+                            }
+                            else
+                            {
+                                xmlWriter.WriteAttributeString("set", "3");
+                            }
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1945,9 +1980,9 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-skin1-joints-array");
                             xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
 
-                            foreach (var b in meshDataList[i].BoneStrings)
+                            foreach (var b in skelDict)
                             {
-                                xmlWriter.WriteString(b + " ");
+                                xmlWriter.WriteString(b.Key + " ");
                             }
                             xmlWriter.WriteEndElement();
                             //</Name_array>
@@ -1957,7 +1992,7 @@ namespace FFXIV_TexTools2.IO
                             //<accessor>
                             xmlWriter.WriteStartElement("accessor");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-skin1-joints-array");
-                            xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
+                            xmlWriter.WriteAttributeString("count", skelDict.Count.ToString());
                             xmlWriter.WriteAttributeString("stride", "1");
                             //<param>
                             xmlWriter.WriteStartElement("param");
@@ -1981,11 +2016,11 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-skin1-bind_poses-array");
                             xmlWriter.WriteAttributeString("count", (16 * meshDataList[i].BoneStrings.Count).ToString());
 
-                            for (int m = 0; m < meshDataList[i].BoneStrings.Count; m++)
+                            foreach (var bone in skelDict)
                             {
                                 try
                                 {
-                                    Matrix matrix = new Matrix(skelDict[meshDataList[i].BoneStrings[m]].InversePoseMatrix);
+                                    Matrix matrix = new Matrix(bone.Value.InversePoseMatrix);
 
                                     xmlWriter.WriteString(matrix.Column1.X + " " + matrix.Column1.Y + " " + matrix.Column1.Z + " " + (matrix.Column1.W * Info.modelMultiplier) + " ");
                                     xmlWriter.WriteString(matrix.Column2.X + " " + matrix.Column2.Y + " " + matrix.Column2.Z + " " + (matrix.Column2.W * Info.modelMultiplier) + " ");
@@ -1994,7 +2029,7 @@ namespace FFXIV_TexTools2.IO
                                 }
                                 catch
                                 {
-                                    Debug.WriteLine("Error at " + meshDataList[i].BoneStrings[m]);
+                                    Debug.WriteLine("Error at " + bone.Key);
                                 }
 
                             }

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -1784,6 +1784,7 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "COLOR");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0");
                             xmlWriter.WriteAttributeString("offset", "2");
+                            xmlWriter.WriteAttributeString("set", "0");
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1792,7 +1793,7 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map0");
                             xmlWriter.WriteAttributeString("offset", "2");
-                            xmlWriter.WriteAttributeString("set", "0");
+                            xmlWriter.WriteAttributeString("set", "1");
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1801,7 +1802,7 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map1");
                             xmlWriter.WriteAttributeString("offset", "2");
-                            xmlWriter.WriteAttributeString("set", "1");
+                            xmlWriter.WriteAttributeString("set", "2");
                             xmlWriter.WriteEndElement();
                             //</input>
 
@@ -1810,6 +1811,7 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2");
                             xmlWriter.WriteAttributeString("offset", "2");
+                            xmlWriter.WriteAttributeString("set", "3");
                             xmlWriter.WriteEndElement();
                             //</input>
 

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -218,7 +218,10 @@ namespace FFXIV_TexTools2.IO
 
                     if (skel.BoneParent == -1)
                     {
-                        skelDict.Add(skel.BoneName, skel);
+                        if (!skelDict.ContainsKey(skel.BoneName))
+                        {
+                            skelDict.Add(skel.BoneName, skel);
+                        }
                     }
 
                     while (skel.BoneParent != -1)

--- a/FFXIV_TexTools2/MainWindow.xaml
+++ b/FFXIV_TexTools2/MainWindow.xaml
@@ -56,6 +56,7 @@
             </MenuItem>
             <MenuItem Header="Search" StaysOpenOnClick="True">
                 <MenuItem Header="Model ID" Command="{Binding IDSearchCommand}"/>
+                <MenuItem Header="Icon ID" Command="{Binding UISearchCommand}"/>
             </MenuItem>
             <MenuItem Header="Options" StaysOpenOnClick="True" Height="22">
                 <MenuItem x:Name="Menu_Directories" Header="Directories" Click="Menu_Directories_Click"/>

--- a/FFXIV_TexTools2/MainWindow.xaml
+++ b/FFXIV_TexTools2/MainWindow.xaml
@@ -60,9 +60,10 @@
             </MenuItem>
             <MenuItem Header="Options" StaysOpenOnClick="True" Height="22">
                 <MenuItem x:Name="Menu_Directories" Header="Directories" Click="Menu_Directories_Click"/>
-                <MenuItem x:Name="Save_All_DDS" Header="Save All DDS" Click="Save_All_DDS_Click" IsEnabled="False"/>
                 <MenuItem x:Name="Menu_Customize" Header="Customize" Click="Menu_Customize_Click"/>
-                
+                <MenuItem x:Name="Menu_ExportSettings" Header="Export Settings" Click="Menu_ExportSettings_Click"/>
+                <MenuItem x:Name="Save_All_DDS" Header="Save All DDS" Click="Save_All_DDS_Click" IsEnabled="False"/>
+
             </MenuItem>
             <MenuItem Header="Help">
                 <MenuItem x:Name="Menu_ProblemCheck" Header="Check For Problems" Click="Menu_ProblemCheck_Click"/>

--- a/FFXIV_TexTools2/MainWindow.xaml
+++ b/FFXIV_TexTools2/MainWindow.xaml
@@ -81,6 +81,7 @@
             <MenuItem Header="Mod Repos">
                 <MenuItem x:Name="PKEmporium" Header="PrettyKitty Emporium" Click="PKEmporium_Click"/>
                 <MenuItem x:Name="NexusMods" Header="Nexus Mods" Click="NexusMods_Click"/>
+                <MenuItem x:Name="XMArchive" Header="XIV Mod Archive" Click="XMArchive_Click"/>
             </MenuItem>
         </Menu>
         <Button Content="Join us on Discord!" VerticalAlignment="Top" HorizontalAlignment="Right" BorderBrush="{x:Null}" Background="{x:Null}" Click="Menu_Discord_Click">

--- a/FFXIV_TexTools2/MainWindow.xaml.cs
+++ b/FFXIV_TexTools2/MainWindow.xaml.cs
@@ -493,6 +493,11 @@ namespace FFXIV_TexTools2
             Process.Start("https://www.nexusmods.com/finalfantasy14");
 
         }
+        private void XMArchive_Click(object sender, RoutedEventArgs e)
+        {
+            Process.Start("https://www.xivmodarchive.com/");
+
+        }
 
         private void Menu_MakeModpack_Click(object sender, RoutedEventArgs e)
         {

--- a/FFXIV_TexTools2/MainWindow.xaml.cs
+++ b/FFXIV_TexTools2/MainWindow.xaml.cs
@@ -570,5 +570,12 @@ namespace FFXIV_TexTools2
             customize.Owner = this;
             customize.Show();
         }
+
+        private void Menu_ExportSettings_Click(object sender, RoutedEventArgs e)
+        {
+            ExportSettings settings = new ExportSettings();
+            settings.Owner = this;
+            settings.Show();
+        }
     }
 }

--- a/FFXIV_TexTools2/MainWindow.xaml.cs
+++ b/FFXIV_TexTools2/MainWindow.xaml.cs
@@ -45,6 +45,7 @@ namespace FFXIV_TexTools2
         public MainWindow()
         {
             InitializeComponent();
+            searchBox.Focus();
             mViewModel = new MainViewModel();
             this.DataContext = mViewModel;
 

--- a/FFXIV_TexTools2/MainWindow.xaml.cs
+++ b/FFXIV_TexTools2/MainWindow.xaml.cs
@@ -28,6 +28,7 @@ using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Configuration;
 using Application = System.Windows.Application;
 
 namespace FFXIV_TexTools2
@@ -39,14 +40,49 @@ namespace FFXIV_TexTools2
     {
         MainViewModel mViewModel;
         CategoryViewModel selectedItem;
-
-
+        
 
         public MainWindow()
         {
-            InitializeComponent();
+            System.Reflection.Assembly assembly = System.Reflection.Assembly.GetExecutingAssembly();
+            FileVersionInfo fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
+            string version = fvi.FileVersion;
+
+            try
+            {
+                InitializeComponent();
+            } catch(System.Windows.Markup.XamlParseException e)
+            {
+                // This occurs when we failed to find a dependency DLL.
+                System.Windows.MessageBox.Show("TexTools was unable to locate dependency files.\nPlease make sure you are running TexTools in the folder it came in.\n\nIf you continue to receive this error,\nPlease make sure your Anti-Virus is not blocking TexTools.", "Dependencies Error v"+ version);
+                Environment.Exit(-1);
+                return;
+            }
+
             searchBox.Focus();
-            mViewModel = new MainViewModel();
+            try
+            {
+                mViewModel = new MainViewModel();
+            } catch(ConfigurationErrorsException ex)
+            {
+                var fname = ex.Filename;
+                if(fname == null && ex.InnerException != null && ex.InnerException.GetType() == typeof(ConfigurationErrorsException))
+                {
+                    fname = ((ConfigurationErrorsException)(ex.InnerException)).Filename;
+                }
+
+                if (File.Exists(fname))
+                {
+                    File.Delete(fname);
+                    System.Windows.MessageBox.Show("TexTools was unable to parse your user config file.\nYour TexTools Configuration has been reset.\n\nPlease restart TexTools.", "Configuration Error v" + version);
+                    Environment.Exit(-1);
+                    return;
+                }
+                else
+                {
+                    throw (ex);   
+                }
+            }
             this.DataContext = mViewModel;
 
             var dxver = Properties.Settings.Default.DX_Ver;

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.8.4")]
+[assembly: AssemblyFileVersion("1.9.8.5")]

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.8.5")]
+[assembly: AssemblyFileVersion("1.9.9.0")]

--- a/FFXIV_TexTools2/Properties/Settings.Designer.cs
+++ b/FFXIV_TexTools2/Properties/Settings.Designer.cs
@@ -190,5 +190,17 @@ namespace FFXIV_TexTools2.Properties {
                 this["BG_Color"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Open Collada")]
+        public string DAE_Plugin_Target {
+            get {
+                return ((string)(this["DAE_Plugin_Target"]));
+            }
+            set {
+                this["DAE_Plugin_Target"] = value;
+            }
+        }
     }
 }

--- a/FFXIV_TexTools2/Properties/Settings.settings
+++ b/FFXIV_TexTools2/Properties/Settings.settings
@@ -44,5 +44,8 @@
     <Setting Name="BG_Color" Type="System.String" Scope="User">
       <Value Profile="(Default)">#FF777777</Value>
     </Setting>
+    <Setting Name="DAE_Plugin_Target" Type="System.String" Scope="User">
+      <Value Profile="(Default)">Open Collada</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/FFXIV_TexTools2/Resources/Strings.Designer.cs
+++ b/FFXIV_TexTools2/Resources/Strings.Designer.cs
@@ -187,6 +187,15 @@ namespace FFXIV_TexTools2.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Autodesk Collada.
+        /// </summary>
+        internal static string AutodeskCollada {
+            get {
+                return ResourceManager.GetString("AutodeskCollada", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Bahamut-Egi.
         /// </summary>
         internal static string Bahamut_Egi {
@@ -1452,6 +1461,15 @@ namespace FFXIV_TexTools2.Resources {
         internal static string OnlineStatusEXD {
             get {
                 return ResourceManager.GetString("OnlineStatusEXD", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OpenCOLLADA.
+        /// </summary>
+        internal static string OpenCollada {
+            get {
+                return ResourceManager.GetString("OpenCollada", resourceCulture);
             }
         }
         

--- a/FFXIV_TexTools2/Resources/Strings.Designer.cs
+++ b/FFXIV_TexTools2/Resources/Strings.Designer.cs
@@ -1105,6 +1105,15 @@ namespace FFXIV_TexTools2.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Left.
+        /// </summary>
+        internal static string Left {
+            get {
+                return ResourceManager.GetString("Left", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Legs.
         /// </summary>
         internal static string Legs {
@@ -1501,11 +1510,29 @@ namespace FFXIV_TexTools2.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Right.
+        /// </summary>
+        internal static string Right {
+            get {
+                return ResourceManager.GetString("Right", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rings.
         /// </summary>
         internal static string Rings {
             get {
                 return ResourceManager.GetString("Rings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rings_Left.
+        /// </summary>
+        internal static string RingsLeft {
+            get {
+                return ResourceManager.GetString("RingsLeft", resourceCulture);
             }
         }
         

--- a/FFXIV_TexTools2/Resources/Strings.de.resx
+++ b/FFXIV_TexTools2/Resources/Strings.de.resx
@@ -261,6 +261,9 @@
   <data name="Language" xml:space="preserve">
     <value>de</value>
   </data>
+  <data name="Left" xml:space="preserve">
+    <value>Links</value>
+  </data>
   <data name="Legs" xml:space="preserve">
     <value>Beine</value>
   </data>
@@ -315,8 +318,14 @@
   <data name="Ramuh_Egi" xml:space="preserve">
     <value>Ramuh Egi</value>
   </data>
+  <data name="Right" xml:space="preserve">
+    <value>Rechts</value>
+  </data>
   <data name="Rings" xml:space="preserve">
     <value>Rings</value>
+  </data>
+  <data name="RingsLeft" xml:space="preserve">
+    <value>Rings Links</value>
   </data>
   <data name="Roegadyn" xml:space="preserve">
     <value>Roegadyn</value>

--- a/FFXIV_TexTools2/Resources/Strings.en.resx
+++ b/FFXIV_TexTools2/Resources/Strings.en.resx
@@ -225,6 +225,9 @@
   <data name="Language" xml:space="preserve">
     <value>en</value>
   </data>
+  <data name="Left" xml:space="preserve">
+    <value>Left</value>
+  </data>
   <data name="Legs" xml:space="preserve">
     <value>Legs</value>
   </data>
@@ -270,8 +273,14 @@
   <data name="Ramuh_Egi" xml:space="preserve">
     <value>Ramuh Egi</value>
   </data>
+  <data name="Right" xml:space="preserve">
+    <value>Right</value>
+  </data>
   <data name="Rings" xml:space="preserve">
     <value>Rings</value>
+  </data>
+  <data name="RingsLeft" xml:space="preserve">
+    <value>Rings Left</value>
   </data>
   <data name="Roegadyn" xml:space="preserve">
     <value>Roegadyn</value>

--- a/FFXIV_TexTools2/Resources/Strings.fr.resx
+++ b/FFXIV_TexTools2/Resources/Strings.fr.resx
@@ -261,6 +261,9 @@
   <data name="Language" xml:space="preserve">
     <value>fr</value>
   </data>
+  <data name="Left" xml:space="preserve">
+    <value>Gauche</value>
+  </data>
   <data name="Legs" xml:space="preserve">
     <value>Jambes</value>
   </data>
@@ -315,8 +318,14 @@
   <data name="Ramuh_Egi" xml:space="preserve">
     <value>Ramuh Egi</value>
   </data>
+  <data name="Right" xml:space="preserve">
+    <value>Droite</value>
+  </data>
   <data name="Rings" xml:space="preserve">
     <value>Bagues</value>
+  </data>
+  <data name="RingsLeft" xml:space="preserve">
+    <value>Bagues Gauche</value>
   </data>
   <data name="Roegadyn" xml:space="preserve">
     <value>Roegadyn</value>

--- a/FFXIV_TexTools2/Resources/Strings.ja.resx
+++ b/FFXIV_TexTools2/Resources/Strings.ja.resx
@@ -264,6 +264,9 @@
   <data name="Language_Change_Ja" xml:space="preserve">
     <value>言語を変更するには、アプリケーションを再起動する必要があります。 \n今すぐ再起動？</value>
   </data>
+  <data name="Left" xml:space="preserve">
+    <value>左</value>
+  </data>
   <data name="Legs" xml:space="preserve">
     <value>脚</value>
   </data>
@@ -318,8 +321,14 @@
   <data name="Ramuh_Egi" xml:space="preserve">
     <value>ラムウ・エギ</value>
   </data>
+  <data name="Right" xml:space="preserve">
+    <value>右</value>
+  </data>
   <data name="Rings" xml:space="preserve">
     <value>指</value>
+  </data>
+  <data name="RingsLeft" xml:space="preserve">
+    <value>指左</value>
   </data>
   <data name="Roegadyn" xml:space="preserve">
     <value>ルガディン</value>

--- a/FFXIV_TexTools2/Resources/Strings.ko.resx
+++ b/FFXIV_TexTools2/Resources/Strings.ko.resx
@@ -225,6 +225,9 @@
   <data name="Language" xml:space="preserve">
     <value>ko</value>
   </data>
+  <data name="Left" xml:space="preserve">
+    <value>왼쪽</value>
+  </data>
   <data name="Legs" xml:space="preserve">
     <value>다리</value>
   </data>
@@ -270,8 +273,14 @@
   <data name="Ramuh_Egi" xml:space="preserve">
     <value>Ramuh Egi</value>
   </data>
+  <data name="Right" xml:space="preserve">
+    <value>권리</value>
+  </data>
   <data name="Rings" xml:space="preserve">
     <value>손가락</value>
+  </data>
+  <data name="RingsLeft" xml:space="preserve">
+    <value>손가락왼쪽</value>
   </data>
   <data name="Roegadyn" xml:space="preserve">
     <value>루가딘</value>

--- a/FFXIV_TexTools2/Resources/Strings.resx
+++ b/FFXIV_TexTools2/Resources/Strings.resx
@@ -711,4 +711,10 @@
   <data name="Right" xml:space="preserve">
     <value>Right</value>
   </data>
+  <data name="AutodeskCollada" xml:space="preserve">
+    <value>Autodesk Collada</value>
+  </data>
+  <data name="OpenCollada" xml:space="preserve">
+    <value>OpenCOLLADA</value>
+  </data>
 </root>

--- a/FFXIV_TexTools2/Resources/Strings.resx
+++ b/FFXIV_TexTools2/Resources/Strings.resx
@@ -702,4 +702,13 @@
   <data name="DemiIMCFolder" xml:space="preserve">
     <value>chara/demihuman/d{0}/obj/equipment/e{1}</value>
   </data>
+  <data name="RingsLeft" xml:space="preserve">
+    <value>Rings_Left</value>
+  </data>
+  <data name="Left" xml:space="preserve">
+    <value>Left</value>
+  </data>
+  <data name="Right" xml:space="preserve">
+    <value>Right</value>
+  </data>
 </root>

--- a/FFXIV_TexTools2/ViewModel/ListViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ListViewModel.cs
@@ -113,6 +113,11 @@ namespace FFXIV_TexTools2.ViewModel
                     {
                         race = race.Substring(race.IndexOf('c') + 1, 4);
                     }
+                    if(entry.fullPath.Contains("skin_m.tex"))
+                    {
+                        // Catch for base skin texture.
+                        race = "0101";
+                    }
                     else
                     {
                         race = race.Substring(race.LastIndexOf('c') + 1, 4);

--- a/FFXIV_TexTools2/ViewModel/MainViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/MainViewModel.cs
@@ -100,11 +100,19 @@ namespace FFXIV_TexTools2.ViewModel
         }
 
         /// <summary>
-        /// Command for the ModList Menu
+        /// Command for the Model ID Search
         /// </summary>
         public ICommand IDSearchCommand
         {
             get { return new RelayCommand(IDSearch); }
+        }
+
+        /// <summary>
+        /// Command for UI Search
+        /// </summary>
+        public ICommand UISearchCommand
+        {
+            get { return new RelayCommand(UISearch); }
         }
 
 
@@ -312,6 +320,15 @@ namespace FFXIV_TexTools2.ViewModel
             modelSearch.Owner = App.Current.MainWindow;
             modelSearch.Show();
         }
+
+        private void UISearch(object obj)
+        {
+            UISearch uiSearch = new UISearch(this);
+            uiSearch.Owner = App.Current.MainWindow;
+            uiSearch.Show();
+        }
+
+
 
 
         /// <summary>

--- a/FFXIV_TexTools2/ViewModel/ModelSearchViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelSearchViewModel.cs
@@ -61,6 +61,7 @@ namespace FFXIV_TexTools2.ViewModel
             {"ear", Strings.Ears },
             {"nek", Strings.Neck },
             {"rir", Strings.Rings },
+            {"ril", Strings.RingsLeft },
             {"wrs", Strings.Wrists }
         };
 
@@ -255,7 +256,7 @@ namespace FFXIV_TexTools2.ViewModel
             List<SearchItems> workList = new List<SearchItems>();
 
             string[] eqSlots = new string[] { "met", "glv", "dwn", "sho", "top",  };
-            string[] acSlots = new string[] { "ear", "nek", "rir", "wrs" };
+            string[] acSlots = new string[] { "ear", "nek", "rir", "wrs", "ril" };
             string[] parts = new string[] { "a", "b", "c", "d" };
             List<int> variantList = new List<int>();
             List<int> bodyList = new List<int>();

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -49,6 +49,7 @@ namespace FFXIV_TexTools2.ViewModel
         bool import3dEnabled, activeEnabled, openEnabled, newCat, advImport3dEnabled;
         string selectedCategory, modelName, fullPath, prevCat, reflectionContent;
         string activeToggle = "Enable/Disable";
+        string statusText = "";
 
         private ObservableCollection<ComboBoxInfo> raceComboInfo = new ObservableCollection<ComboBoxInfo>();
         private ObservableCollection<ComboBoxInfo> meshComboInfo = new ObservableCollection<ComboBoxInfo>();
@@ -60,6 +61,9 @@ namespace FFXIV_TexTools2.ViewModel
         private ComboBoxInfo selectedPart;
         private ComboBoxInfo selectedBody;
 
+        private float StatusTextDuration = 3.0f;
+        private System.Timers.Timer StatusTextTimer;
+
         public int RaceIndex { get { return raceIndex; } set { raceIndex = value; NotifyPropertyChanged("RaceIndex"); } }
         public int MeshIndex { get { return meshIndex; } set { meshIndex = value; NotifyPropertyChanged("MeshIndex"); } }
         public int BodyIndex { get { return bodyIndex; } set { bodyIndex = value; NotifyPropertyChanged("BodyIndex"); } }
@@ -67,6 +71,7 @@ namespace FFXIV_TexTools2.ViewModel
 
         public string ReflectionContent { get { return reflectionContent; } set { reflectionContent = value; NotifyPropertyChanged("ReflectionContent"); } }
         public string ActiveToggle { get { return activeToggle; } set { activeToggle = value; NotifyPropertyChanged("ActiveToggle"); } }
+        public string StatusText { get { return statusText; } set { statusText = value; NotifyPropertyChanged("StatusText"); } }
 
         public bool RaceEnabled { get { return raceEnabled; } set { raceEnabled = value; NotifyPropertyChanged("RaceEnabled"); } }
         public bool MeshEnabled { get { return meshEnabled; } set { meshEnabled = value; NotifyPropertyChanged("MeshEnabled"); } }
@@ -93,6 +98,36 @@ namespace FFXIV_TexTools2.ViewModel
         public void ReloadModel()
         {
             UpdateModel(selectedItem, selectedCategory);
+        }
+
+        // Shows the given status text for the standard duration.
+        private void ShowStatusText(string text, bool error = false)
+        {
+            if(error)
+            {
+                text = "Error: " + text;
+            }
+
+            StatusText = text;
+
+            if(StatusTextTimer != null)
+            {
+                StatusTextTimer.Stop();
+                StatusTextTimer.Dispose();
+            }
+
+
+            StatusTextTimer = new System.Timers.Timer(StatusTextDuration * 1000);
+            // Hook up the Elapsed event for the timer. 
+            StatusTextTimer.AutoReset = false;
+            StatusTextTimer.Enabled = true;
+            StatusTextTimer.Elapsed += new System.Timers.ElapsedEventHandler(ClearStatusText);
+
+        }
+
+        private void ClearStatusText(object Sender, EventArgs e)
+        {
+            StatusText = "";
         }
 
 
@@ -137,7 +172,7 @@ namespace FFXIV_TexTools2.ViewModel
                 {
                     RaceComboBoxChanged();
                 }
-                
+                ShowStatusText("Model Updated Successfully");
             }
             else
             {

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -124,7 +124,19 @@ namespace FFXIV_TexTools2.ViewModel
 
             if(RaceComboBox.Count > 0 && !itemChanged)
             {
-                RaceComboBoxChanged();
+                if(BodyComboBox.Count > 0)
+                {
+                    if(PartComboBox.Count > 0)
+                    {
+                        PartComboBoxChanged();
+                    } else
+                    {
+                        BodyComboBoxChanged();
+                    }
+                } else
+                {
+                    RaceComboBoxChanged();
+                }
                 
             }
             else

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -127,6 +127,12 @@ namespace FFXIV_TexTools2.ViewModel
 
         private void ClearStatusText(object Sender, EventArgs e)
         {
+            if (StatusTextTimer != null)
+            {
+                StatusTextTimer.Stop();
+                StatusTextTimer.Dispose();
+            }
+
             StatusText = "";
         }
 
@@ -176,6 +182,7 @@ namespace FFXIV_TexTools2.ViewModel
             }
             else
             {
+                ClearStatusText(null, null);
                 try
                 {
                     string categoryType = Helper.GetCategoryType(selectedCategory);
@@ -703,6 +710,8 @@ namespace FFXIV_TexTools2.ViewModel
         {
             try
             {
+                ClearStatusText(null, null);
+
                 is3DLoaded = false;
                 bool isDemiHuman = false;
 
@@ -905,6 +914,8 @@ namespace FFXIV_TexTools2.ViewModel
         {
             try
             {
+                ClearStatusText(null, null);
+                
                 is3DLoaded = false;
 
                 if (CompositeVM != null && !disposing)

--- a/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ModelViewModel.cs
@@ -798,6 +798,11 @@ namespace FFXIV_TexTools2.ViewModel
                         }
                     }
                 }
+                else if (selectedCategory.Equals(Strings.Rings))
+                {
+                    cbi.Add(new ComboBoxInfo() { Name = Strings.Right, ID = Strings.Right, IsNum = false });
+                    cbi.Add(new ComboBoxInfo() { Name = Strings.Left, ID = Strings.Left, IsNum = false });
+                }
                 else
                 {
                     cbi.Add(new ComboBoxInfo() { Name = "-", ID = "-", IsNum = false });

--- a/FFXIV_TexTools2/ViewModel/UISearchViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/UISearchViewModel.cs
@@ -1,0 +1,87 @@
+﻿// FFXIV TexTools
+// Copyright © 2017 Rafael Gonzalez - All Rights Reserved
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using FFXIV_TexTools2.Helpers;
+using FFXIV_TexTools2.Model;
+using FFXIV_TexTools2.Resources;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Windows;
+using System.Windows.Input;
+
+namespace FFXIV_TexTools2.ViewModel
+{
+    public class UISearchViewModel : INotifyPropertyChanged
+    {
+        private string idText;
+        private MainViewModel parentVM;
+        private Window window;
+
+        public ICommand OpenAction { get { return new RelayCommand(Open); } }
+        public string IdText { get { return idText; } set { idText = value; } }
+
+        public UISearchViewModel(MainViewModel parent, Window self)
+        {
+            parentVM = parent;
+            window = self;
+        }
+
+        public void Open(object o)
+        {
+            var idNum = 0;
+
+            if(!int.TryParse(idText, out idNum))
+            {
+                FlexibleMessageBox.Show("Invalid Texture ID.","Invalid ID Error");
+                return;
+            }
+
+            int folderNumber = (idNum / 1000) * 1000;
+            var folderName = folderNumber.ToString();
+            while(folderName.Length < 6)
+            {
+                folderName = "0" + folderName;
+            }
+
+            var fileName = idText + ".tex";
+            var filePath = "ui/icon/" + folderName;
+
+            ItemData itemData = new ItemData()
+            {
+                ItemName = fileName,
+                ItemCategory = Strings.Other,
+                ItemSubCategory = "Other",
+                UIPath = filePath,
+            };
+
+            parentVM.TextureVM.UpdateTexture(itemData, "UI");
+            window.Close();
+        }
+
+
+
+
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        protected void NotifyPropertyChanged(string propertyName)
+        {
+            if (this.PropertyChanged != null)
+                PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+        }
+        
+    }
+}

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8.4 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8.5 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.8.5 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.0 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/ExportSettings.xaml
+++ b/FFXIV_TexTools2/Views/ExportSettings.xaml
@@ -1,0 +1,21 @@
+﻿<Window x:Class="FFXIV_TexTools2.Views.ExportSettings"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:FFXIV_TexTools2.Views"
+        mc:Ignorable="d"
+        Title="ExportSettings" Width="437.295" ResizeMode="NoResize" Height="89.981">
+    <Grid>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition MaxWidth="150" MinWidth="150" Width="150*"/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="50*" MaxHeight="50" MinHeight="50"/>
+        </Grid.RowDefinitions>
+        <ComboBox x:Name="DAETargetComboBox" HorizontalAlignment="Left" Margin="10,0" VerticalAlignment="Center" Width="247" Grid.Column="1" SelectionChanged="DAETargetComboBox_SelectionChanged"/>
+        <Label Content="Target DAE Importer" HorizontalAlignment="Left" Margin="10,0" VerticalAlignment="Center" RenderTransformOrigin="0.481,0.291"/>
+
+    </Grid>
+</Window>

--- a/FFXIV_TexTools2/Views/ExportSettings.xaml.cs
+++ b/FFXIV_TexTools2/Views/ExportSettings.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using FFXIV_TexTools2.Helpers;
+
+namespace FFXIV_TexTools2.Views
+{
+    /// <summary>
+    /// Interaction logic for ExportSettings.xaml
+    /// </summary>
+    public partial class ExportSettings : Window
+    {
+        public ExportSettings()
+        {
+            InitializeComponent();
+
+            DAETargetComboBox.ItemsSource = Info.DAEPluginTargets;
+
+            foreach( var item in DAETargetComboBox.Items )
+            {
+                if(Properties.Settings.Default.DAE_Plugin_Target == item.ToString())
+                {
+                    DAETargetComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+            
+        }
+
+        private void DAETargetComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            Properties.Settings.Default.DAE_Plugin_Target = DAETargetComboBox.SelectedItem.ToString();
+            Properties.Settings.Default.Save();
+        }
+    }
+}

--- a/FFXIV_TexTools2/Views/ImportModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/ImportModPack.xaml.cs
@@ -280,7 +280,7 @@ namespace FFXIV_TexTools2.Views
         /// <returns>The texture map name</returns>
         private static string GetMapName(string fileName)
         {
-            if (fileName.Contains("_s.tex"))
+            if (fileName.Contains("_s.tex") || fileName.Contains("skin_m"))
             {
                 return Strings.Specular;
             }
@@ -294,14 +294,7 @@ namespace FFXIV_TexTools2.Views
             }
             else if (fileName.Contains("_m.tex"))
             {
-                if (fileName.Contains("skin"))
-                {
-                    return Strings.Skin;
-                }
-                else
-                {
-                    return Strings.Mask;
-                }
+                return Strings.Mask;
             }
             else if (fileName.Contains("decal"))
             {

--- a/FFXIV_TexTools2/Views/ImportModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/ImportModPack.xaml.cs
@@ -231,7 +231,7 @@ namespace FFXIV_TexTools2.Views
 
         private ModPackJson deserializeModPackJsonLine(string line) {
             var data = JsonConvert.DeserializeObject<ModPackJson>(line);
-            data.ModOffset = (uint)data.ModOffset;
+            data.ModOffset = data.ModOffset;
             return data;
         }
 
@@ -442,6 +442,7 @@ namespace FFXIV_TexTools2.Views
 
                                         foreach (var mpi in pack)
                                         {
+
                                             currentImport = mpi.Name + "....";
                                             backgroundWorker.ReportProgress((int)((i / packListCount) * 100), currentImport);
 
@@ -470,14 +471,16 @@ namespace FFXIV_TexTools2.Views
                                                     }
                                                     lineNum++;
                                                 }
+                                                
 
+                                                
 
                                                 var datNum = int.Parse(Info.ModDatDict[mpi.mEntry.DatFile]);
 
                                                 var modDatPath = string.Format(Info.datDir, mpi.mEntry.DatFile, datNum);
 
                                                 var fileLength = new FileInfo(modDatPath).Length;
-                                                while (fileLength >= 2000000000)
+                                                while (fileLength + mpi.mEntry.ModSize >= 2000000000)
                                                 {
                                                     datNum += 1;
                                                     modDatPath = string.Format(Info.datDir, mpi.mEntry.DatFile, datNum);
@@ -613,7 +616,6 @@ namespace FFXIV_TexTools2.Views
 
                                 }
                             }
-                    
                             stream.Dispose();
                             stream.Close();
                         }

--- a/FFXIV_TexTools2/Views/ImportModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/ImportModPack.xaml.cs
@@ -270,6 +270,7 @@ namespace FFXIV_TexTools2.Views
             {"ear", Strings.Ears},
             {"nek", Strings.Neck},
             {"rir", Strings.Rings},
+            {"ril", Strings.RingsLeft},
             {"wrs", Strings.Wrists},
         };
 

--- a/FFXIV_TexTools2/Views/MakeModPack.xaml
+++ b/FFXIV_TexTools2/Views/MakeModPack.xaml
@@ -8,9 +8,10 @@
         Title="Modpack Creator" Height="500" Width="700" WindowStyle="ToolWindow" WindowStartupLocation="CenterOwner">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="20*"/>
-            <RowDefinition Height="2*"/>
-            <RowDefinition Height="1*"/>
+            <RowDefinition Height="369*"/>
+            <RowDefinition Height="40*" MaxHeight="40"/>
+            <RowDefinition Height="40*" MaxHeight="40"/>
+            <RowDefinition Height="25*"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
@@ -28,13 +29,18 @@
             </Grid.Resources>
             -->
             <Grid.RowDefinitions>
-                <RowDefinition Height="2*"/>
-                <RowDefinition Height="1*"/>
-                <RowDefinition Height="15*"/>
+                <RowDefinition Height="60*" MaxHeight="60"/>
+                <RowDefinition Height="40*" MaxHeight="40"/>
+                <RowDefinition Height="292*"/>
             </Grid.RowDefinitions>
             <Grid Grid.Row="0">
                 <Label x:Name="InfoHeader" BorderBrush="Black" BorderThickness="0,1,0,0" />
             </Grid>
+            <StackPanel Orientation="Horizontal" Grid.Row="1" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}" Margin="0,5">
+                <Button x:Name="SelectAllButton" Content="Select All" Margin="0,0,20,0" Click="SelectAllButton_Click"/>
+                <Button x:Name="SelectActiveButton" Content="Select Active" Margin="0,0,20,0" Click="SelectActiveButton_Click"/>
+                <Button x:Name="ClearSelectedButton" Content="Clear Selected" Margin="0,0,20,0" Click="ClearSelectedButton_Click"/>
+            </StackPanel>
             <ListView x:Name="listView" Grid.Row="2" SelectionChanged="listView_SelectionChanged" SelectionMode="Multiple"
                       BorderBrush="Black" BorderThickness="0,1" AlternationCount="2" GridViewColumnHeader.Click="Header_Click">
                 <ListView.ItemsPanel>
@@ -60,13 +66,8 @@
                     </GridView>
                 </ListView.View>
             </ListView>
-            <StackPanel Orientation="Horizontal" Grid.Row="1" Background="{DynamicResource {x:Static SystemColors.ControlBrushKey}}">
-                <Button x:Name="SelectAllButton" Content="Select All" Margin="0,0,20,0" Click="SelectAllButton_Click"/>
-                <Button x:Name="SelectActiveButton" Content="Select Active" Margin="0,0,20,0" Click="SelectActiveButton_Click"/>
-                <Button x:Name="ClearSelectedButton" Content="Clear Selected" Margin="0,0,20,0" Click="ClearSelectedButton_Click"/>
-            </StackPanel>
         </Grid>
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="3*"/>
                 <ColumnDefinition Width="1*"/>
@@ -85,11 +86,19 @@
                 <Button x:Name="CreateButton" Content="Create" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Left" Click="CreateButton_Click" IsEnabled="False" Padding="3,1"/>
             </Grid>
         </Grid>
-        <StatusBar x:Name="StatusBar" Grid.Row="2" >
+        <StatusBar x:Name="StatusBar" Grid.Row="3" >
             <Label Content="Count: " Padding="0" />
             <Label x:Name="ModCountLabel" Content="0 " Padding="0"/>
             <Label Content=" Size: " Padding="0" />
             <Label x:Name="ModSizeLabel" Content="0" Padding="0"/>
         </StatusBar>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="3*"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>
+            <Label Content="Search:" Grid.Column="0" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="0" />
+            <TextBox x:Name="SearchBox" Margin="53,5,147,5" KeyDown="SearchBox_KeyDown"/>
+        </Grid>
     </Grid>
 </Window>

--- a/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
@@ -603,7 +603,7 @@ namespace FFXIV_TexTools2.Views
                         {
                             foreach (var part in broken)
                             {
-                              if(!x.Name.ToLower().Contains(part))
+                              if(!x.Name.ToLower().Contains(part.ToLower().Trim()))
                                 {
                                     return false;
                                 }

--- a/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
@@ -217,7 +217,7 @@ namespace FFXIV_TexTools2.Views
         /// <returns>The texture map name</returns>
         private static string GetMapName(string fileName)
         {
-            if (fileName.Contains("_s.tex"))
+            if (fileName.Contains("_s.tex") || fileName.Contains("skin_m"))
             {
                 return Strings.Specular;
             }
@@ -231,14 +231,7 @@ namespace FFXIV_TexTools2.Views
             }
             else if (fileName.Contains("_m.tex"))
             {
-                if (fileName.Contains("skin"))
-                {
-                    return Strings.Skin;
-                }
-                else
-                {
-                    return Strings.Mask;
-                }
+                return Strings.Mask;
             }
             else if (fileName.Contains(".atex"))
             {

--- a/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
@@ -13,6 +13,8 @@ using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Threading;
 using Forms = System.Windows.Forms;
+using System.Linq;
+using System.Collections.ObjectModel;
 
 namespace FFXIV_TexTools2.Views
 {
@@ -34,14 +36,16 @@ namespace FFXIV_TexTools2.Views
         DispatcherTimer dt = new DispatcherTimer();
         Stopwatch sw = new Stopwatch();
         private string tempMPL, tempMPD;
+        ObservableCollection<ModPackItems> ListItems;
+        List<ModPackItems> FullModList;
 
 
         public MakeModPack()
         {
             InitializeComponent();
 
+            var mpiList = new List<ModPackItems>();
             dt.Tick += new EventHandler(dt_Tick);
-            List<ModPackItems> mpiList = new List<ModPackItems>();
 
             InfoHeader.Content = "This tool will create a zipped TexTools Mod Pack (*.ttmp) file of the selected mods in the following directory:\n" + mpDir;
             try
@@ -185,7 +189,10 @@ namespace FFXIV_TexTools2.Views
                     }
                 }
                 mpiList.Sort();
-                listView.ItemsSource = mpiList;               
+                FullModList = mpiList;
+                ListItems = new ObservableCollection<ModPackItems>(mpiList);
+                listView.ItemsSource = ListItems;
+                SearchBox.Focus();
             }
             catch (Exception ex)
             {
@@ -570,6 +577,45 @@ namespace FFXIV_TexTools2.Views
         private void ClearSelectedButton_Click(object sender, RoutedEventArgs e)
         {
             listView.UnselectAll();
+        }
+
+        private void SearchBox_KeyDown(object sender, System.Windows.Input.KeyEventArgs e)
+        {
+            if(e.Key == System.Windows.Input.Key.Enter)
+            {
+                var searches = SearchBox.Text.Split('|');
+                if (searches.Length == 0 || (searches.Length == 1 && searches[0].Trim() == ""))
+                {
+                    ListItems = new ObservableCollection<ModPackItems>(FullModList);
+                }
+                else
+                {
+                    var tempList = new List<ModPackItems>();
+                    foreach (var search in searches)
+                    {
+                        var trimmed = search.Trim().ToLower();
+
+                        // Simple wildcard support.
+                        // Full Regex is probably too much, but basic wildcard should be useful.
+                        var broken = search.Split('*');
+                        
+                        tempList = tempList.Concat(FullModList.Where(x =>
+                        {
+                            foreach (var part in broken)
+                            {
+                              if(!x.Name.ToLower().Contains(part))
+                                {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        })).ToList();
+                    }
+                    ListItems = new ObservableCollection<ModPackItems>(tempList);
+                }
+                
+                listView.ItemsSource = ListItems;
+            }
         }
 
         private void Header_Click(object sender, RoutedEventArgs e)

--- a/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
+++ b/FFXIV_TexTools2/Views/MakeModPack.xaml.cs
@@ -329,6 +329,7 @@ namespace FFXIV_TexTools2.Views
             {"ear", Strings.Ears},
             {"nek", Strings.Neck},
             {"rir", Strings.Rings},
+            {"ril", Strings.RingsLeft},
             {"wrs", Strings.Wrists},
         };
 

--- a/FFXIV_TexTools2/Views/ModelSearch.xaml
+++ b/FFXIV_TexTools2/Views/ModelSearch.xaml
@@ -55,7 +55,7 @@
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
             <ComboBox Grid.Column="0" Margin="5" ItemsSource="{Binding TypeComboBox}" DisplayMemberPath="Name" SelectedValuePath="Name" SelectedItem="{Binding SelectedType}" SelectedIndex="{Binding TypeIndex}" VerticalContentAlignment="Center" HorizontalContentAlignment="Center"/>
-            <TextBox Grid.Column="1" Text="{Binding ModelSearchText}" VerticalContentAlignment="Center" Margin="5"/>
+            <TextBox x:Name="SearchBox" Grid.Column="1" Text="{Binding ModelSearchText}" VerticalContentAlignment="Center" Margin="5"/>
             <Button Content="Search" Command="{Binding ModelSearchCommand}" IsEnabled="{Binding SearchEnabled}" Grid.Column="2" Margin="5"/>
         </Grid>
         <Grid Grid.Row="1" Height="32" VerticalAlignment="Top">

--- a/FFXIV_TexTools2/Views/ModelSearch.xaml
+++ b/FFXIV_TexTools2/Views/ModelSearch.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:FFXIV_TexTools2.Views"
         mc:Ignorable="d"
-        Title="ModelSearch" Height="300" Width="450" ResizeMode="NoResize" WindowStartupLocation="CenterOwner">
+        Title="ModelSearch" Height="421.398" Width="450" ResizeMode="CanResizeWithGrip" WindowStartupLocation="CenterOwner" MinWidth="450" MinHeight="400">
     <Window.Resources>
         <DataTemplate x:Key="SlotBorderTemplate">
             <Border BorderBrush="#FF000000" BorderThickness="0,0,1,1" Margin="-6,-2,-6,-2">
@@ -43,12 +43,12 @@
     </Window.Resources>
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="50*"/>
-            <RowDefinition Height="50*"/>
-            <RowDefinition Height="250*"/>
-            <RowDefinition Height="50*"/>
+            <RowDefinition Height="34*"/>
+            <RowDefinition Height="34*"/>
+            <RowDefinition Height="294*"/>
+            <RowDefinition Height="29*"/>
         </Grid.RowDefinitions>
-        <Grid Grid.Row="0">
+        <Grid Grid.Row="0" Height="35" VerticalAlignment="Top" Grid.RowSpan="2">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
                 <ColumnDefinition/>
@@ -58,16 +58,19 @@
             <TextBox Grid.Column="1" Text="{Binding ModelSearchText}" VerticalContentAlignment="Center" Margin="5"/>
             <Button Content="Search" Command="{Binding ModelSearchCommand}" IsEnabled="{Binding SearchEnabled}" Grid.Column="2" Margin="5"/>
         </Grid>
-        <Grid Grid.Row="1">
+        <Grid Grid.Row="1" Height="32" VerticalAlignment="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <ProgressBar Grid.Column="0" Margin="5" Value="{Binding ProgressValue}"/>
-            <Label Content="{Binding ProgressLabel}" Grid.Column="1" VerticalContentAlignment="Center" Padding="0"/>
+            <ProgressBar Grid.Column="0" Margin="5,5,0,0" Value="{Binding ProgressValue}" HorizontalAlignment="Left" Width="211" Height="22" VerticalAlignment="Top"/>
+            <Label Content="{Binding ProgressLabel}" Grid.Column="1" VerticalContentAlignment="Center" Padding="0" Height="32" VerticalAlignment="Top" HorizontalAlignment="Left" Width="221"/>
         </Grid>
         <Grid Grid.Row="2">
-            <ListView Margin="5" ItemContainerStyle="{DynamicResource BorderItemContainerStyle}" ItemsSource="{Binding ResultList}" SelectionMode="Single" SelectedItem="{Binding SelectedItem}">
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <ListView Margin="5,0" ItemContainerStyle="{DynamicResource BorderItemContainerStyle}" ItemsSource="{Binding ResultList}" SelectionMode="Single" SelectedItem="{Binding SelectedItem}">
                 <ListView.View>
                     <GridView>
                         <GridViewColumn Header="Slot" Width="100" CellTemplate="{DynamicResource SlotBorderTemplate}"/>
@@ -78,13 +81,13 @@
                 </ListView.View>
             </ListView>
         </Grid>
-        <Grid Grid.Row="3">
+        <Grid Grid.Row="3" Height="27" VerticalAlignment="Bottom">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="10*"/>
                 <ColumnDefinition Width="1*"/>
             </Grid.ColumnDefinitions>
-            <TextBox Text="{Binding MTRLPath}" IsReadOnly="True" Grid.Column="0" VerticalContentAlignment="Center"/>
-            <Button Content="Open" Grid.Column="1" Command="{Binding OpenCommand}" IsEnabled="{Binding OpenEnabled, FallbackValue=false}"/>
+            <TextBox Text="{Binding MTRLPath}" IsReadOnly="True" Grid.Column="0" VerticalContentAlignment="Center" Height="27" VerticalAlignment="Bottom"/>
+            <Button Content="Open" Grid.Column="1" Command="{Binding OpenCommand}" IsEnabled="{Binding OpenEnabled, FallbackValue=false}" Height="27" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="40"/>
         </Grid>
     </Grid>
 </Window>

--- a/FFXIV_TexTools2/Views/ModelSearch.xaml.cs
+++ b/FFXIV_TexTools2/Views/ModelSearch.xaml.cs
@@ -28,6 +28,7 @@ namespace FFXIV_TexTools2.Views
         {
             InitializeComponent();
             this.DataContext = new ModelSearchViewModel(parent);
+            SearchBox.Focus();
         }
     }
 }

--- a/FFXIV_TexTools2/Views/ModelView.xaml
+++ b/FFXIV_TexTools2/Views/ModelView.xaml
@@ -53,6 +53,7 @@
                         Color="{Binding Light1Color}" />
                     <hx:ItemsModel3D ItemsSource="{Binding ModelCollection}"  />
                 </hx:Viewport3DX>
+                <Label x:Name="StatusLabel" Content="{Binding StatusText, FallbackValue=Status Text}" Margin="0" Height="50" Panel.ZIndex="10" FontSize="18" HorizontalAlignment="Center" VerticalAlignment="Bottom" FontStyle="Italic" Foreground="#FF151515"/>
             </Grid>
         </GroupBox>
         <Grid Margin="10,0,10,46" VerticalAlignment="Bottom">

--- a/FFXIV_TexTools2/Views/UISearch.xaml
+++ b/FFXIV_TexTools2/Views/UISearch.xaml
@@ -1,0 +1,48 @@
+﻿<Window x:Class="FFXIV_TexTools2.Views.UISearch"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:FFXIV_TexTools2.Views"
+        mc:Ignorable="d"
+        Title="UI Icon Search" Height="83.928" Width="461.606" ResizeMode="NoResize" WindowStartupLocation="CenterOwner" MinWidth="450" MinHeight="75">
+    <Window.Resources>
+        <DataTemplate x:Key="SlotBorderTemplate">
+            <Border BorderBrush="#FF000000" BorderThickness="0,0,1,1" Margin="-6,-2,-6,-2">
+                <StackPanel Margin="6,2,6,2">
+                    <TextBlock Text="{Binding Slot}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="BodyBorderTemplate">
+            <Border BorderBrush="#FF000000" BorderThickness="0,0,1,1" Margin="-6,-2,-6,-2">
+                <StackPanel Margin="6,2,6,2">
+                    <TextBlock Text="{Binding Body}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="VariantBorderTemplate">
+            <Border BorderBrush="#FF000000" BorderThickness="0,0,1,1" Margin="-6,-2,-6,-2">
+                <StackPanel Margin="6,2,6,2">
+                    <TextBlock Text="{Binding Variant}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+        <DataTemplate x:Key="PartBorderTemplate">
+            <Border BorderBrush="#FF000000" BorderThickness="0,0,0,1" Margin="-6,-2,-6,-2">
+                <StackPanel Margin="6,2,6,2">
+                    <TextBlock Text="{Binding Part}"/>
+                </StackPanel>
+            </Border>
+        </DataTemplate>
+
+        <Style x:Key="BorderItemContainerStyle" TargetType="{x:Type ListViewItem}">
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+            <Setter Property="VerticalContentAlignment" Value="Stretch" />
+        </Style>
+    </Window.Resources>
+    <Canvas Margin="0" Height="50" Width="450" HorizontalAlignment="Left" VerticalAlignment="Top">
+        <Button x:Name="OpenButton" Content="Open" Margin="0" VerticalAlignment="Top" Width="80" Height="26" Canvas.Left="354" Canvas.Top="9.5" HorizontalAlignment="Left" Command="{Binding OpenAction}"/>
+        <TextBox x:Name="IdTexBox" Text="{Binding IdText}" Height="26" Canvas.Left="10" TextWrapping="Wrap" Canvas.Top="10" Width="339" HorizontalAlignment="Left" VerticalAlignment="Top" KeyDown="IdTexBox_KeyDown"/>
+    </Canvas>
+</Window>

--- a/FFXIV_TexTools2/Views/UISearch.xaml.cs
+++ b/FFXIV_TexTools2/Views/UISearch.xaml.cs
@@ -1,0 +1,45 @@
+﻿// FFXIV TexTools
+// Copyright © 2017 Rafael Gonzalez - All Rights Reserved
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// 
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using FFXIV_TexTools2.ViewModel;
+using System.Windows;
+using System.Windows.Input;
+
+namespace FFXIV_TexTools2.Views
+{
+    /// <summary>
+    /// Interaction logic for ModelSearch.xaml
+    /// </summary>
+    public partial class UISearch : Window
+    {
+        public UISearch(MainViewModel parent)
+        {
+            InitializeComponent();
+            this.DataContext = new UISearchViewModel(parent, this);
+            IdTexBox.Focus();
+        }
+
+        private void IdTexBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                var context = ((UISearchViewModel)DataContext);
+                context.IdText = IdTexBox.Text;
+                context.Open(null);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ ChangeLog:
 For previous ChangeLogs visit http://ffxivtextools.dualwield.net/change_log.html
 
 Application: 
+- Guest update by Sel [https://github.com/Lunaretic]
 - Skin Specular maps are now editable again for non-Au Ra races, and are viewable again in the ModList view.
   - The shared skin_m texture is now always referred to as a 'specular', to match the Au Ra version.
 - Added Search Bar to Make Modpack Menu
@@ -24,9 +25,10 @@ Application:
 - Vertex Color is now imported/exported correctly.
 - Vertex Alpha is now imported/exported correctly.
   - As a work-around due to inconsistency with DAE parsers/exporters, Vertex Alpha is stored in the X(U) channel of UV3.
-- UV2, Vertex Color, and Vertex Alpha data are now dummied up with default values, in the event that it does not exist in the incoming DAE file.
+- UV, Vertex Color, and Vertex Alpha data are now dummied up with default values, in the event that it does not exist in the incoming DAE file.
 - 3D Meshes now support multiple UV Coordinates and Normals per-Vertex.
   - As a byproduct to this, the Model Import process may slow down significantly when dealing with extremely large mesh groups (50k+ Faces).  (Ex. 78,000 Face mesh group took 65 seconds to import)
+- For Gear and Character Models, UV1 Data is now automatically moved to the UV[1,-1] quadrant, if it is not already in that quadrant.
 - BiNormal/Tangent data is no longer required in the DAE file, since TT recalculates them anyways.
 - Added error message for mesh groups exceeding maximum size.
 - Added status message display after importing/enabling/disabling a model.
@@ -42,4 +44,3 @@ Bugfixes:
 
 Known Issues:
  - Skeleton files may need updating for some newer items. (Ex. Some Hairstyles and Bonewicca pieces)
- - 3D Meshes with multiple Normals per Vertex may have extra UV Seams when Exported back out from TexTools.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Application:
 - Version Number updated to 1.9.9.0
 
 3D:
+- Left Rings are now able to be viewed/modified.
 - Vertex Color is now imported/exported correctly.
 - Vertex Alpha is now imported/exported correctly.
   - As a work-around due to inconsistency with DAE parsers/exporters, Vertex Alpha is stored in the X(U) channel of UV3.
@@ -26,12 +27,14 @@ Application:
   - As a byproduct to this, the Model Import process may slow down significantly when dealing with extremely large mesh groups (50k+ Faces).  (Ex. 78,000 Face mesh group took 65 seconds to import)
 - BiNormal/Tangent data is no longer required in the DAE file, since TT recalculates them anyways.
 - Added error message for mesh groups exceeding maximum size.
+- Added status message display after importing/enabling/disabling a model.
 
 Bugfixes:
 - Fixed a bug with Modpack Import that would cause it to break if the uncompressed modpack size was greater than ~4GB.
 - Fixed a bug with importing that would allow DAT files to exceed the appropriate size.
 - Fixed a bug with Model Importing that would cause model indices to be thrown off if there was extraneous unused UV/Normal/Vertex Color/etc. data.
 - Fixed a bug with DAE imports that would cause a crash if the meshes had extra data channels in them (ex. extra UV channels).
+- Fixed a bug that would cause the 3D Model display to revert back to the default item after using import/enable/disable.
 
 
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Application:
 - Added Human Readable Error Messages for common start-up errors.
 - Broken TexTools config files will now be automatically reset.
 - XIV Mod Archive added to Repos menu.
+- Added Icon ID Search Menu
+- Added Export Settings Menu
 - Version Number updated to 1.9.9.0
 
 3D:
@@ -39,6 +41,7 @@ Bugfixes:
 - Fixed a bug with Model Importing that would cause model indices to be thrown off if there was extraneous unused UV/Normal/Vertex Color/etc. data.
 - Fixed a bug with DAE imports that would cause a crash if the meshes had extra data channels in them (ex. extra UV channels).
 - Fixed a bug that would cause the 3D Model display to revert back to the default item after using import/enable/disable.
+- Autodesk Collada exported DAE files can now be imported.
 
 
 


### PR DESCRIPTION
Application: 
- Skin Specular maps are now editable again for non-Au Ra races, and are viewable again in the ModList view.
  - The shared skin_m texture is now always referred to as a 'specular', to match the Au Ra version.
- Added Search Bar to Make Modpack Menu
  - Search supports Wildcards via Asterisk(*), and 'Or' via Pipes(|)
- Search for Model menu is now resize-able.
- UI now defaults focus to search bars in menus where they are available.
- XIV Mod Archive added to Repos menu.
- Version Number updated to 1.9.9.0

3D:
- Left Rings are now viewable and modifiable.
- Vertex Color is now imported/exported correctly.
- Vertex Alpha is now imported/exported correctly.
  - As a work-around due to inconsistency with DAE parsers/exporters, Vertex Alpha is stored in the X(U) channel of UV3.
- UV2, Vertex Color, and Vertex Alpha data are now dummied up with default values, in the event that it does not exist in the incoming DAE file.
- 3D Meshes now support multiple UV Coordinates and Normals per-Vertex.
  - As a byproduct to this, the Model Import process may slow down significantly when dealing with extremely large mesh groups (50k+ Faces).  (Ex. 78,000 Face mesh group took 65 seconds to import)
- BiNormal/Tangent data is no longer required in the DAE file, since TT recalculates them anyways.
- Added error message for mesh groups exceeding maximum size.

Bugfixes:
- Fixed a bug with Modpack Import that would cause it to break if the uncompressed modpack size was greater than ~4GB.
- Fixed a bug with importing that would allow DAT files to exceed the appropriate size.
- Fixed a bug with Model Importing that would cause model indices to be thrown off if there was extraneous unused UV/Normal/Vertex Color/etc. data.
- Fixed a bug with DAE imports that would cause a crash if the meshes had extra data channels in them (ex. extra UV channels).