### PR TITLE
1.9.9.1 Hotfix for Export Bone Weights

### DIFF
--- a/FFXIV_TexTools2/App.config
+++ b/FFXIV_TexTools2/App.config
@@ -53,7 +53,7 @@
                 <value>#FF777777</value>
             </setting>
             <setting name="DAE_Plugin_Target" serializeAs="String">
-                <value>Open Collada</value>
+                <value>OpenCOLLADA</value>
             </setting>
         </FFXIV_TexTools2.Properties.Settings>
     </userSettings>

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -1980,9 +1980,11 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-skin1-joints-array");
                             xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
 
-                            foreach (var b in skelDict)
+                            var modelBoneStrings = meshDataList[i].BoneStrings;
+
+                            foreach (var b in modelBoneStrings)
                             {
-                                xmlWriter.WriteString(b.Key + " ");
+                                xmlWriter.WriteString(b + " ");
                             }
                             xmlWriter.WriteEndElement();
                             //</Name_array>
@@ -1992,7 +1994,7 @@ namespace FFXIV_TexTools2.IO
                             //<accessor>
                             xmlWriter.WriteStartElement("accessor");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-skin1-joints-array");
-                            xmlWriter.WriteAttributeString("count", skelDict.Count.ToString());
+                            xmlWriter.WriteAttributeString("count", modelBoneStrings.Count.ToString());
                             xmlWriter.WriteAttributeString("stride", "1");
                             //<param>
                             xmlWriter.WriteStartElement("param");
@@ -2014,13 +2016,14 @@ namespace FFXIV_TexTools2.IO
                             //<Name_array>
                             xmlWriter.WriteStartElement("float_array");
                             xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-skin1-bind_poses-array");
-                            xmlWriter.WriteAttributeString("count", (16 * meshDataList[i].BoneStrings.Count).ToString());
+                            xmlWriter.WriteAttributeString("count", (16 * modelBoneStrings.Count).ToString());
 
-                            foreach (var bone in skelDict)
+                            foreach (var boneName in modelBoneStrings)
                             {
                                 try
                                 {
-                                    Matrix matrix = new Matrix(bone.Value.InversePoseMatrix);
+                                    var bone = skelDict[boneName];
+                                    Matrix matrix = new Matrix(bone.InversePoseMatrix);
 
                                     xmlWriter.WriteString(matrix.Column1.X + " " + matrix.Column1.Y + " " + matrix.Column1.Z + " " + (matrix.Column1.W * Info.modelMultiplier) + " ");
                                     xmlWriter.WriteString(matrix.Column2.X + " " + matrix.Column2.Y + " " + matrix.Column2.Z + " " + (matrix.Column2.W * Info.modelMultiplier) + " ");
@@ -2029,7 +2032,7 @@ namespace FFXIV_TexTools2.IO
                                 }
                                 catch
                                 {
-                                    Debug.WriteLine("Error at " + bone.Key);
+                                    Debug.WriteLine("Error at " + boneName);
                                 }
 
                             }
@@ -2041,7 +2044,7 @@ namespace FFXIV_TexTools2.IO
                             //<accessor>
                             xmlWriter.WriteStartElement("accessor");
                             xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-skin1-bind_poses-array");
-                            xmlWriter.WriteAttributeString("count", meshDataList[i].BoneStrings.Count.ToString());
+                            xmlWriter.WriteAttributeString("count", modelBoneStrings.ToString());
                             xmlWriter.WriteAttributeString("stride", "16");
                             //<param>
                             xmlWriter.WriteStartElement("param");

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.9.0")]
+[assembly: AssemblyFileVersion("1.9.9.1")]

--- a/FFXIV_TexTools2/Properties/Settings.Designer.cs
+++ b/FFXIV_TexTools2/Properties/Settings.Designer.cs
@@ -193,7 +193,7 @@ namespace FFXIV_TexTools2.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("Open Collada")]
+        [global::System.Configuration.DefaultSettingValueAttribute("OpenCOLLADA")]
         public string DAE_Plugin_Target {
             get {
                 return ((string)(this["DAE_Plugin_Target"]));

--- a/FFXIV_TexTools2/Properties/Settings.settings
+++ b/FFXIV_TexTools2/Properties/Settings.settings
@@ -45,7 +45,7 @@
       <Value Profile="(Default)">#FF777777</Value>
     </Setting>
     <Setting Name="DAE_Plugin_Target" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Open Collada</Value>
+      <Value Profile="(Default)">OpenCOLLADA</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.0 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.1 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # FFXIV TexTools 2 by Liinko
 This is a more feature rich WPF implementation of FFXIV TexTools and replaced FFXIV TexTools.
 
-# Current Version: 1.9.9.0
+# Current Version: 1.9.9.1
 ChangeLog:
 
 For previous ChangeLogs visit http://ffxivtextools.dualwield.net/change_log.html


### PR DESCRIPTION
Sorry, had a bug in a commit from last night that I hadn't fully tested out yet.

1.9.9.1
- Fixes an bug where some exported meshes had incorrect bone/skin weights.
- Fixes a bug which caused the default DAE Exporter to be 'Open Collada' instead of 'OpenCOLLADA'