### PR TITLE
1.9.9.2

### DIFF
--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -387,7 +387,11 @@ namespace FFXIV_TexTools2.IO
                                     var vColorOffset = -1;
                                     var vAlphaOffset = -1;
                                     var totalStride = -1;
+
+                                    // Vars that control if we should dump the Vertex data that came in,
+                                    // if it looked invalid.
                                     var scrubVertexAlphas = false;
+                                    var scrubVertexColors = false;
 
 
 
@@ -531,9 +535,15 @@ namespace FFXIV_TexTools2.IO
                                                 }
 
                                                 // Vertex Color
-                                                if (cData.vertexColors.Count == 0)
+                                                if (cData.vertexColors.Count == 0 || cData.vertexColors.Any(x => x < 0f || x > 1.0f))
                                                 {
-                                                    // If we have no VertexColor data, just add a 1.0 value for everything.
+                                                    // If it was bad data, mark it for scrubbing.
+                                                    if (cData.vertexColors.Count > 0)
+                                                    {
+                                                        scrubVertexColors = true;
+                                                    }
+
+                                                    // Full color used for missing/bad data.
                                                     cData.vertexColors.Add(1.0f);
                                                     cData.vertexColors.Add(1.0f);
                                                     cData.vertexColors.Add(1.0f);
@@ -661,7 +671,7 @@ namespace FFXIV_TexTools2.IO
 														cData.tc2IndexList.Add(cData.index[i + texCoord2Offset]);
 													}
 
-                                                    if(vColorOffset != -1)
+                                                    if(vColorOffset != -1 && !scrubVertexColors)
                                                     {
                                                         cData.vcIndexList.Add(cData.index[i + vColorOffset]);
                                                     }
@@ -1799,10 +1809,10 @@ namespace FFXIV_TexTools2.IO
 					id.dataSet2.Add(tw);
 
                     //Color
-                    byte r = Convert.ToByte(Math.Round(cmd.vertexColors[i].X * 255));
-                    byte g = Convert.ToByte(Math.Round(cmd.vertexColors[i].Y * 255));
-                    byte b = Convert.ToByte(Math.Round(cmd.vertexColors[i].Z * 255));
-                    byte a = Convert.ToByte(Math.Round(cmd.vertexAlphas[i] * 255));
+                    byte r = Convert.ToByte(Helper.Clamp((int)Math.Round(cmd.vertexColors[i].X * 255), 0, 255));
+                    byte g = Convert.ToByte(Helper.Clamp((int)Math.Round(cmd.vertexColors[i].Y * 255), 0, 255));
+                    byte b = Convert.ToByte(Helper.Clamp((int)Math.Round(cmd.vertexColors[i].Z * 255), 0, 255));
+                    byte a = Convert.ToByte(Math.Round(cmd.vertexAlphas[i] * 255)); // Alpha was clamped earlier.
                     id.dataSet2.Add(r);
                     id.dataSet2.Add(g);
                     id.dataSet2.Add(b);

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -913,9 +913,33 @@ namespace FFXIV_TexTools2.IO
 
 
                                                     var bString = blendBoneName;
+
+                                                    // Hair bones *sometimes* end in numbers.
                                                     if (!blendBoneName.Contains("h0"))
                                                     {
                                                         bString = Regex.Replace(blendBoneName, @"[\d]", string.Empty);
+                                                    } else
+                                                    {
+                                                        // For hair bones, see if we have any subset matches.
+                                                        foreach (var bone in CustomBoneSet)
+                                                        {
+                                                            if(bString.Contains(bone.Key))
+                                                            {
+                                                                // The Key is the correct one, assume it's name.
+                                                                bString = bone.Key;
+                                                                break;
+
+                                                            } else if (bone.Key.Contains(bString))
+                                                            {
+                                                                // The bString is correct, adjust the hair key..?
+                                                                var val = bone.Value;
+                                                                var key = bone.Key;
+                                                                CustomBoneSet.Remove(key);
+                                                                CustomBoneSet.Add(bString, val);
+                                                                break;
+                                                            }
+                                                        }
+                                                        
                                                     }
 
 

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -461,7 +461,7 @@ namespace FFXIV_TexTools2.IO
                                                         cData.texCoord.Add(0.0f);
                                                     }
 
-                                                } else if(isGearModel || category == Strings.Character)
+                                                } else if(isGearModel || (category == Strings.Character && itemName != Strings.Face))
                                                 {
                                                     // Skipped for monsters/etc. since it's possible some of those may use
                                                     // unique shaders which use other UV quadrants.

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -361,14 +361,7 @@ namespace FFXIV_TexTools2.IO
                                     //go to geometry element
                                 if (reader.Name.Equals("geometry"))
 								{
-									var atr = reader["id"];
-
-
-                                    if (tool.Contains("OpenCOLLADA-Maya"))
-                                    {
-                                        atr = reader["id"];
-                                    }
-
+									var atr = reader["name"];
                                     var id = reader["id"];
 
 								    try

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -923,7 +923,7 @@ namespace FFXIV_TexTools2.IO
 
 
                                                     // Strip trailing numbers - No bones actually *end* in numbers, even if they contain numbers.
-                                                    var bString = Regex.Replace(blendBoneName, "^.*([0-9])+$", string.Empty);
+                                                    var bString = Regex.Replace(blendBoneName, "[0-9]+$", string.Empty);
 
 
                                                     if (importSettings[Strings.All].UseOriginalBones)

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -333,6 +333,18 @@ namespace FFXIV_TexTools2.IO
 										return;
 									}
                                 }
+                                if (reader.Name.Contains("comments") && tool.Contains("OpenCOLLADA"))
+                                {
+                                    var comments = reader.ReadElementContentAsString().ToLower();
+                                    if(comments.Contains("colladamaya"))
+                                    {
+                                        tool = "OpenCOLLADA-Maya";
+                                    } else if(comments.Contains("colladamax")) 
+                                    {
+                                        tool = "OpenCOLLADA-Max";
+                                    }
+                                }
+
                                 if (reader.Name.Contains("tool_settings") && tool.Contains("TexTools"))
                                 {
                                     var daeTarget = reader.ReadElementContentAsString();
@@ -347,10 +359,17 @@ namespace FFXIV_TexTools2.IO
                                 }
 
                                     //go to geometry element
-                                    if (reader.Name.Equals("geometry"))
+                                if (reader.Name.Equals("geometry"))
 								{
-									var atr = reader["name"];
-									var id = reader["id"];
+									var atr = reader["id"];
+
+
+                                    if (tool.Contains("OpenCOLLADA-Maya"))
+                                    {
+                                        atr = reader["id"];
+                                    }
+
+                                    var id = reader["id"];
 
 								    try
 								    {
@@ -1431,12 +1450,18 @@ namespace FFXIV_TexTools2.IO
                             for(var z = 0; z < uniqueCount; z++)
                             {
                                 var targetEntry = uniquesList[z];
+                                var normId = listEntry[1];
+                                var uv1Id = listEntry[2];
+                                var uv2Id = listEntry[3];
+
+                                var normValue = Normals[listEntry[1]];
+
 
                                 // We only really care about matching on position, normal, and UV1/2
                                 if(listEntry[0] == targetEntry[0]
-                                    && listEntry[1] == targetEntry[1]
-                                    && listEntry[2] == targetEntry[2]
-                                    && listEntry[3] == targetEntry[3])
+                                    && Normals[listEntry[1]] == Normals[targetEntry[1]]
+                                    && TexCoord[listEntry[2]] == TexCoord[targetEntry[2]]
+                                    && TexCoord2[listEntry[3]] == TexCoord2[targetEntry[3]])
                                 {
                                     targetIndex = z;
                                     break;

--- a/FFXIV_TexTools2/IO/ImportModel.cs
+++ b/FFXIV_TexTools2/IO/ImportModel.cs
@@ -912,35 +912,8 @@ namespace FFXIV_TexTools2.IO
                                                     }
 
 
-                                                    var bString = blendBoneName;
-
-                                                    // Hair bones *sometimes* end in numbers.
-                                                    if (!blendBoneName.Contains("h0"))
-                                                    {
-                                                        bString = Regex.Replace(blendBoneName, @"[\d]", string.Empty);
-                                                    } else
-                                                    {
-                                                        // For hair bones, see if we have any subset matches.
-                                                        foreach (var bone in CustomBoneSet)
-                                                        {
-                                                            if(bString.Contains(bone.Key))
-                                                            {
-                                                                // The Key is the correct one, assume it's name.
-                                                                bString = bone.Key;
-                                                                break;
-
-                                                            } else if (bone.Key.Contains(bString))
-                                                            {
-                                                                // The bString is correct, adjust the hair key..?
-                                                                var val = bone.Value;
-                                                                var key = bone.Key;
-                                                                CustomBoneSet.Remove(key);
-                                                                CustomBoneSet.Add(bString, val);
-                                                                break;
-                                                            }
-                                                        }
-                                                        
-                                                    }
+                                                    // Strip trailing numbers - No bones actually *end* in numbers, even if they contain numbers.
+                                                    var bString = Regex.Replace(blendBoneName, "^.*([0-9])+$", string.Empty);
 
 
                                                     if (importSettings[Strings.All].UseOriginalBones)

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -1405,71 +1405,73 @@ namespace FFXIV_TexTools2.IO
                              * --------------------
                              */
 
-                            //<source>
-                            xmlWriter.WriteStartElement("source");
-                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-col0");
-                            //<float_array>
-                            xmlWriter.WriteStartElement("float_array");
-                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-col0-array");
-                            xmlWriter.WriteAttributeString("count", (totalCount * 3).ToString());
-                            
                             var vertexColors = meshList[i].VertexColors.GetRange(totalVertices, totalCount);
+                            if (!(indexCount <= 3 && pluginTarget == Strings.AutodeskCollada)) {
+                                //<source>
+                                xmlWriter.WriteStartElement("source");
+                                xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-col0");
+                                //<float_array>
+                                xmlWriter.WriteStartElement("float_array");
+                                xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-col0-array");
+                                xmlWriter.WriteAttributeString("count", (totalCount * 3).ToString());
+                            
 
-                            foreach (var vc in vertexColors)
-                            {
-                                float r = vc.Red / 255.0f;
-                                float g = vc.Green / 255.0f;
-                                float b = vc.Blue / 255.0f;
-                                //float a = vc.Alpha / 255.0f;
+                                foreach (var vc in vertexColors)
+                                {
+                                    float r = vc.Red / 255.0f;
+                                    float g = vc.Green / 255.0f;
+                                    float b = vc.Blue / 255.0f;
+                                    //float a = vc.Alpha / 255.0f;
 
-                                xmlWriter.WriteString(r.ToString() + " " + g.ToString() + " " + b.ToString() + " ");
+                                    xmlWriter.WriteString(r.ToString() + " " + g.ToString() + " " + b.ToString() + " ");
+                                }
+
+                                xmlWriter.WriteEndElement();
+                                //</float_array>
+
+                                //<technique_common>
+                                xmlWriter.WriteStartElement("technique_common");
+                                //<accessor>
+                                xmlWriter.WriteStartElement("accessor");
+                                xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0-array");
+                                xmlWriter.WriteAttributeString("count", totalCount.ToString());
+                                xmlWriter.WriteAttributeString("stride", "3");
+
+                                //<param>
+                                xmlWriter.WriteStartElement("param");
+                                xmlWriter.WriteAttributeString("name", "R");
+                                xmlWriter.WriteAttributeString("type", "float");
+                                xmlWriter.WriteEndElement();
+                                //</param>
+
+                                //<param>
+                                xmlWriter.WriteStartElement("param");
+                                xmlWriter.WriteAttributeString("name", "G");
+                                xmlWriter.WriteAttributeString("type", "float");
+                                xmlWriter.WriteEndElement();
+                                //</param>
+
+                                //<param>
+                                xmlWriter.WriteStartElement("param");
+                                xmlWriter.WriteAttributeString("name", "B");
+                                xmlWriter.WriteAttributeString("type", "float");
+                                xmlWriter.WriteEndElement();
+                                //</param>
+
+                                //<param>
+                                /*xmlWriter.WriteStartElement("param");
+                                xmlWriter.WriteAttributeString("name", "A");
+                                xmlWriter.WriteAttributeString("type", "float");
+                                xmlWriter.WriteEndElement();*/
+                                //</param>
+
+                                xmlWriter.WriteEndElement();
+                                //</accessor>
+                                xmlWriter.WriteEndElement();
+                                //</technique_common>
+                                xmlWriter.WriteEndElement();
+                                //</source>
                             }
-
-                            xmlWriter.WriteEndElement();
-                            //</float_array>
-
-                            //<technique_common>
-                            xmlWriter.WriteStartElement("technique_common");
-                            //<accessor>
-                            xmlWriter.WriteStartElement("accessor");
-                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0-array");
-                            xmlWriter.WriteAttributeString("count", totalCount.ToString());
-                            xmlWriter.WriteAttributeString("stride", "3");
-
-                            //<param>
-                            xmlWriter.WriteStartElement("param");
-                            xmlWriter.WriteAttributeString("name", "R");
-                            xmlWriter.WriteAttributeString("type", "float");
-                            xmlWriter.WriteEndElement();
-                            //</param>
-
-                            //<param>
-                            xmlWriter.WriteStartElement("param");
-                            xmlWriter.WriteAttributeString("name", "G");
-                            xmlWriter.WriteAttributeString("type", "float");
-                            xmlWriter.WriteEndElement();
-                            //</param>
-
-                            //<param>
-                            xmlWriter.WriteStartElement("param");
-                            xmlWriter.WriteAttributeString("name", "B");
-                            xmlWriter.WriteAttributeString("type", "float");
-                            xmlWriter.WriteEndElement();
-                            //</param>
-
-                            //<param>
-                            /*xmlWriter.WriteStartElement("param");
-                            xmlWriter.WriteAttributeString("name", "A");
-                            xmlWriter.WriteAttributeString("type", "float");
-                            xmlWriter.WriteEndElement();*/
-                            //</param>
-
-                            xmlWriter.WriteEndElement();
-                            //</accessor>
-                            xmlWriter.WriteEndElement();
-                            //</technique_common>
-                            xmlWriter.WriteEndElement();
-                            //</source>
 
                             /*
                              * --------------------
@@ -1587,55 +1589,58 @@ namespace FFXIV_TexTools2.IO
                              * --------------------
                              */
 
-                            //<source>
-                            xmlWriter.WriteStartElement("source");
-                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-map2");
-                            //<float_array>
-                            xmlWriter.WriteStartElement("float_array");
-                            xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-map2-array");
-                            xmlWriter.WriteAttributeString("count", (totalCount * 2).ToString());
-
-                            vertexColors = meshList[i].VertexColors.GetRange(totalVertices, totalCount);
-
-                            foreach (var vc in vertexColors)
+                            if (!(indexCount <= 3 && pluginTarget == Strings.AutodeskCollada))
                             {
-                                float a = vc.Alpha / 255.0f;
+                                //<source>
+                                xmlWriter.WriteStartElement("source");
+                                xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-map2");
+                                //<float_array>
+                                xmlWriter.WriteStartElement("float_array");
+                                xmlWriter.WriteAttributeString("id", "geom-" + modelName + "_" + i + partString + "-map2-array");
+                                xmlWriter.WriteAttributeString("count", (totalCount * 2).ToString());
 
-                                // Use the UV S channel for the Alpha data, since OpenCollada doesn't play with it nicely.
-                                xmlWriter.WriteString(a.ToString() + " 0 ");
+                                vertexColors = meshList[i].VertexColors.GetRange(totalVertices, totalCount);
+
+                                foreach (var vc in vertexColors)
+                                {
+                                    float a = vc.Alpha / 255.0f;
+
+                                    // Use the UV S channel for the Alpha data, since OpenCollada doesn't play with it nicely.
+                                    xmlWriter.WriteString(a.ToString() + " 0 ");
+                                }
+
+                                xmlWriter.WriteEndElement();
+                                //</float_array>
+
+                                //<technique_common>
+                                xmlWriter.WriteStartElement("technique_common");
+                                //<accessor>
+                                xmlWriter.WriteStartElement("accessor");
+                                xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2-array");
+                                xmlWriter.WriteAttributeString("count", totalCount.ToString());
+                                xmlWriter.WriteAttributeString("stride", "2");
+
+                                //<param>
+                                xmlWriter.WriteStartElement("param");
+                                xmlWriter.WriteAttributeString("name", "S");
+                                xmlWriter.WriteAttributeString("type", "float");
+                                xmlWriter.WriteEndElement();
+                                //</param>
+
+                                //<param>
+                                xmlWriter.WriteStartElement("param");
+                                xmlWriter.WriteAttributeString("name", "T");
+                                xmlWriter.WriteAttributeString("type", "float");
+                                xmlWriter.WriteEndElement();
+                                //</param>
+
+                                xmlWriter.WriteEndElement();
+                                //</accessor>
+                                xmlWriter.WriteEndElement();
+                                //</technique_common>
+                                xmlWriter.WriteEndElement();
+                                //</source>
                             }
-
-                            xmlWriter.WriteEndElement();
-                            //</float_array>
-
-                            //<technique_common>
-                            xmlWriter.WriteStartElement("technique_common");
-                            //<accessor>
-                            xmlWriter.WriteStartElement("accessor");
-                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2-array");
-                            xmlWriter.WriteAttributeString("count", totalCount.ToString());
-                            xmlWriter.WriteAttributeString("stride", "2");
-
-                            //<param>
-                            xmlWriter.WriteStartElement("param");
-                            xmlWriter.WriteAttributeString("name", "S");
-                            xmlWriter.WriteAttributeString("type", "float");
-                            xmlWriter.WriteEndElement();
-                            //</param>
-
-                            //<param>
-                            xmlWriter.WriteStartElement("param");
-                            xmlWriter.WriteAttributeString("name", "T");
-                            xmlWriter.WriteAttributeString("type", "float");
-                            xmlWriter.WriteEndElement();
-                            //</param>
-
-                            xmlWriter.WriteEndElement();
-                            //</accessor>
-                            xmlWriter.WriteEndElement();
-                            //</technique_common>
-                            xmlWriter.WriteEndElement();
-                            //</source>
 
                             /*
                              * --------------------
@@ -1794,14 +1799,17 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteEndElement();
                             //</input>
 
-                            //<input>
-                            xmlWriter.WriteStartElement("input");
-                            xmlWriter.WriteAttributeString("semantic", "COLOR");
-                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0");
-                            xmlWriter.WriteAttributeString("offset", "2");
-                            xmlWriter.WriteAttributeString("set", "0");
-                            xmlWriter.WriteEndElement();
-                            //</input>
+                            if (!(indexCount <= 3 && pluginTarget == Strings.AutodeskCollada))
+                            {
+                                //<input>
+                                xmlWriter.WriteStartElement("input");
+                                xmlWriter.WriteAttributeString("semantic", "COLOR");
+                                xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-col0");
+                                xmlWriter.WriteAttributeString("offset", "2");
+                                xmlWriter.WriteAttributeString("set", "0");
+                                xmlWriter.WriteEndElement();
+                                //</input>
+                            }
 
                             //<input>
                             xmlWriter.WriteStartElement("input");
@@ -1836,22 +1844,25 @@ namespace FFXIV_TexTools2.IO
                             xmlWriter.WriteEndElement();
                             //</input>
 
-                            //<input>
-                            xmlWriter.WriteStartElement("input");
-                            xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
-                            xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2");
-                            xmlWriter.WriteAttributeString("offset", "2");
-                            if (pluginTarget == Strings.AutodeskCollada)
+                            if (!(indexCount <= 3 && pluginTarget == Strings.AutodeskCollada))
                             {
-                                xmlWriter.WriteAttributeString("set", "2");
+                                //<input>
+                                xmlWriter.WriteStartElement("input");
+                                xmlWriter.WriteAttributeString("semantic", "TEXCOORD");
+                                xmlWriter.WriteAttributeString("source", "#geom-" + modelName + "_" + i + partString + "-map2");
+                                xmlWriter.WriteAttributeString("offset", "2");
+                                if (pluginTarget == Strings.AutodeskCollada)
+                                {
+                                    xmlWriter.WriteAttributeString("set", "2");
 
+                                }
+                                else
+                                {
+                                    xmlWriter.WriteAttributeString("set", "3");
+                                }
+                                xmlWriter.WriteEndElement();
+                                //</input>
                             }
-                            else
-                            {
-                                xmlWriter.WriteAttributeString("set", "3");
-                            }
-                            xmlWriter.WriteEndElement();
-                            //</input>
 
                             //<input>
                             xmlWriter.WriteStartElement("input");

--- a/FFXIV_TexTools2/IO/SaveModel.cs
+++ b/FFXIV_TexTools2/IO/SaveModel.cs
@@ -1146,7 +1146,13 @@ namespace FFXIV_TexTools2.IO
                     //<transparent>
                     xmlWriter.WriteStartElement("transparent");
 
-                    xmlWriter.WriteAttributeString("opaque", "RGB_ZERO");
+                    if (Properties.Settings.Default.DAE_Plugin_Target == Strings.AutodeskCollada)
+                    {
+                        xmlWriter.WriteAttributeString("opaque", "RGB_ZERO");
+                    } else
+                    {
+                        xmlWriter.WriteAttributeString("opaque", "A_ONE");
+                    }
 
 
                     //<texture>

--- a/FFXIV_TexTools2/Model/ModListModel.cs
+++ b/FFXIV_TexTools2/Model/ModListModel.cs
@@ -30,6 +30,8 @@ namespace FFXIV_TexTools2.Model
         public string Map { get; set; }
         public string Part { get; set; }
         public string Type { get; set; }
+        public string DXType { get; set; }
+
         public SolidColorBrush Active
         {
             get { return _active; }

--- a/FFXIV_TexTools2/Properties/AssemblyInfo.cs
+++ b/FFXIV_TexTools2/Properties/AssemblyInfo.cs
@@ -52,4 +52,4 @@ using System.Windows;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.9.9.1")]
+[assembly: AssemblyFileVersion("1.9.9.2")]

--- a/FFXIV_TexTools2/ViewModel/ListViewModel.cs
+++ b/FFXIV_TexTools2/ViewModel/ListViewModel.cs
@@ -134,6 +134,14 @@ namespace FFXIV_TexTools2.ViewModel
 
             mlm.Race = race;
 
+            if(entry.fullPath.Contains("--"))
+            {
+                mlm.DXType = Strings.DX11;
+            } else
+            {
+                mlm.DXType = Strings.DX9;
+            }
+
 
             if (entry.fullPath.Contains("_d."))
             {

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.2 Alpha&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.2 Beta&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.2 Beta&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.2&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/About.xaml
+++ b/FFXIV_TexTools2/Views/About.xaml
@@ -20,7 +20,7 @@
                     <RowDefinition Height="2*"/>
                     <RowDefinition/>
                 </Grid.RowDefinitions>
-                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.1 &#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
+                <TextBox Grid.Row="0" TextWrapping="Wrap" AcceptsReturn="True" Text="FFXIV TexTools 2&#xA;Version 1.9.9.2 Alpha&#xA;Created By Liinko" IsReadOnly="True" FontSize="20" BorderThickness="0" TextChanged="TextBox_TextChanged"/>
                 <Button x:Name="DonateButton" Grid.Row="1" BorderBrush="{x:Null}" Click="DonateButton_Click" Foreground="{x:Null}" Background="{x:Null}" HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch" >
                     <Button.Content>
                         <Image Source="/FFXIV TexTools 2;component/Resources/PaypalDonateButton.png" Stretch="Uniform"/>

--- a/FFXIV_TexTools2/Views/ModList.xaml
+++ b/FFXIV_TexTools2/Views/ModList.xaml
@@ -56,6 +56,8 @@
                                         <RowDefinition Height="2*"/>
                                         <RowDefinition/>
                                         <RowDefinition Height="2*"/>
+                                        <RowDefinition/>
+                                        <RowDefinition Height="2*"/>
                                     </Grid.RowDefinitions>
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="1*"/>
@@ -83,6 +85,11 @@
                                     <Border BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="1" Grid.Column="1" Grid.Row="3">
                                         <Viewbox StretchDirection="DownOnly">
                                             <Label Content="{Binding Type}"/>
+                                        </Viewbox>
+                                    </Border>
+                                    <Border BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" BorderThickness="1" Grid.Row="4">
+                                        <Viewbox StretchDirection="DownOnly">
+                                            <Label Content="{Binding DXType}"/>
                                         </Viewbox>
                                     </Border>
 


### PR DESCRIPTION
Composed of bugfixes for small stuff people had pop over the last two weeks on 1.9.9.1.  Some new bugs, some old bugs.

- Fix for select face models crashing 3DS on import when imported with Autodesk Collada Importer.
- Fix for Face models having UVs pushed into UV [1,-1] when they shouldn't be.
- Fix for OpenCOLLADA transparency being rendered improperly in 3DS.
- Modlist menu now shows DX9/DX11 status, defaulting to DX9 if it is used for both.
- UV, UV2, and Normal data is now treated as an identical if the value is matching, even if the index number is not.
- Hair Bones will now properly be merged together in the event there are multiple bones.
- Version number updated to 1.9.9.2